### PR TITLE
fix(kiro): use single-quoted env exports in MCP wrapper to prevent ba…

### DIFF
--- a/src/backend/kiro.ts
+++ b/src/backend/kiro.ts
@@ -53,9 +53,9 @@ export class KiroBackend implements CliBackend {
       // Write a wrapper script that sets env vars explicitly
       const wrapperPath = join(this.instanceDir, `mcp-wrapper-${name}.sh`);
       const envExports = Object.entries(allEnv)
-        .map(([k, v]) => `export ${k}=${JSON.stringify(v)}`)
+        .map(([k, v]) => `export ${k}='${String(v).replace(/'/g, "'\\''")}'`)
         .join("\n");
-      writeFileSync(wrapperPath, `#!/bin/bash\n${envExports}\nexec ${entry.command} ${entry.args.map((a: string) => JSON.stringify(a)).join(" ")}\n`);
+      writeFileSync(wrapperPath, `#!/bin/bash\n${envExports}\n# Wait for IPC socket to be ready (up to 10s)\nfor i in $(seq 1 20); do [ -S "$AGEND_SOCKET_PATH" ] && break; sleep 0.5; done\nexec ${entry.command} ${entry.args.map((a: string) => JSON.stringify(a)).join(" ")}\n`);
       chmodSync(wrapperPath, 0o755);
 
       servers[instanceKey] = {


### PR DESCRIPTION
This pull request makes a targeted improvement to the wrapper script generation in the `KiroBackend` class. The update ensures that environment variables containing single quotes are safely exported in the shell script, and adds logic to wait for the IPC socket to be ready before executing the main command.

Key improvements to script robustness and reliability:

* Properly escapes single quotes in environment variable values when generating the wrapper shell script to prevent syntax errors.
* Adds a loop to the wrapper script that waits (up to 10 seconds) for the IPC socket (`$AGEND_SOCKET_PATH`) to become available before launching the main process, improving startup reliability.…cktick/dollar interpretation

AGEND_DECISIONS contains markdown with backticks which broke bash double-quoted strings. Also add socket readiness wait before exec.