### PR TITLE
fix: Discord onboarding — startup_timeout_ms, snowflake precision, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ agend fleet start               # 3. Launch your fleet 🎉
 
 Open Telegram, send a message to your bot, and start coding from your phone.
 
+> **Discord?** `agend quickstart` supports Discord too — install the plugin first: `npm install -g @suzuke/agend-plugin-discord`. See [Discord setup guide](docs/features.md#discord-adapter-mvp).
+
 ## How It Works
 
 ```mermaid

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,7 +68,7 @@ health_port: 19280
 | `type` | `"telegram"` \| `"discord"` | **required** | Messaging platform |
 | `mode` | `"topic"` | `"topic"` | Routing mode (topic = one topic per instance) |
 | `bot_token_env` | string | **required** | Environment variable name holding the bot token |
-| `group_id` | number | — | Telegram group ID (negative) or Discord guild ID |
+| `group_id` | number \| string | — | Telegram group ID (negative) or Discord guild ID. Quote Discord snowflake IDs to prevent precision loss. |
 | `access` | object | **required** | Access control settings |
 | `mirror_topic_id` | number \| string | — | Telegram topic ID for mirroring cross-instance communication. All `send_to_instance` messages appear here |
 | `options` | object | — | Platform-specific options (Discord: `category_name`, `general_channel_id`) |
@@ -95,6 +95,7 @@ All fields from `instances.<name>` can be set here as defaults. Additionally:
 | `daily_summary` | object | enabled, 21:00 | Daily cost summary |
 | `scheduler` | object | — | Scheduler settings |
 | `webhooks` | object[] | `[]` | Webhook notifications |
+| `startup_timeout_ms` | number | `25000` | Total CLI backend startup timeout in ms (split 60/40 between output detection and idle wait) |
 
 ### defaults.cost_guard
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -246,14 +246,57 @@ defaults:
 
 ## Discord adapter (MVP)
 
-Connect your fleet to Discord instead of (or alongside) Telegram. Configure in `fleet.yaml`:
+Connect your fleet to Discord instead of (or alongside) Telegram.
 
-```yaml
-channel:
-  type: discord
-  bot_token_env: CCD_DISCORD_TOKEN
-  guild_id: "123456789"
-```
+### Setup
+
+1. **Install the Discord plugin:**
+   ```bash
+   npm install -g @suzuke/agend-plugin-discord
+   ```
+
+2. **Create a Discord bot** at [Discord Developer Portal](https://discord.com/developers/applications):
+   - Create a new Application → Bot
+   - Enable **Privileged Gateway Intents**: Presence Intent, Server Members Intent, Message Content Intent
+   - Generate an invite URL with `bot` scope and `Send Messages`, `Read Message History`, `Manage Channels` permissions
+   - Invite the bot to your server
+
+3. **Run the quickstart** (recommended for Discord):
+   ```bash
+   agend quickstart    # Select "Discord" when prompted
+   ```
+   > **Note:** `agend init` (advanced wizard) currently supports Telegram only. Use `agend quickstart` for Discord setup.
+
+4. **Or configure manually** in `fleet.yaml`:
+   ```yaml
+   channel:
+     type: discord
+     mode: topic           # Required — omitting this silently prevents bot startup
+     bot_token_env: AGEND_DISCORD_TOKEN
+     group_id: "123456789012345678"   # Quote Discord snowflake IDs to prevent precision loss
+     access:
+       mode: locked
+       allowed_users:
+         - "your_discord_user_id"     # Also quote user IDs
+   ```
+
+5. **Set the bot token** in `~/.agend/.env`:
+   ```
+   AGEND_DISCORD_TOKEN=your_bot_token_here
+   ```
+
+### Troubleshooting
+
+- **Bot doesn't come online:** Ensure `mode: topic` is set in `fleet.yaml`. Without it, the adapter silently never starts.
+- **Messages are empty:** Enable **Message Content Intent** in Discord Developer Portal → Bot → Privileged Gateway Intents.
+- **ID precision loss:** Always quote Discord IDs (guild ID, user ID) in YAML — they are 64-bit snowflakes that exceed JavaScript integer precision.
+- **Slow startup with MCP:** If backend CLI times out during startup due to MCP server connections, increase the timeout in `fleet.yaml`:
+  ```yaml
+  defaults:
+    startup_timeout_ms: 60000   # Default: 25000 (25s)
+  ```
+- **`registerBotCommands` ETIMEDOUT:** This is non-fatal — bot polling starts regardless. Occurs on unstable networks.
+- **`working_directory` not found:** Directories are auto-created since v1.19. If you see this error, update to the latest version.
 
 ## External adapter plugin system
 

--- a/docs/features.zh-TW.md
+++ b/docs/features.zh-TW.md
@@ -260,14 +260,57 @@ defaults:
 
 ## Discord 轉接器 (Discord adapter (MVP))
 
-將您的 fleet 連接到 Discord 而非（或同時連接）Telegram。在 `fleet.yaml` 中配置：
+將您的 fleet 連接到 Discord 而非（或同時連接）Telegram。
 
-```yaml
-channel:
-  type: discord
-  bot_token_env: AGEND_DISCORD_TOKEN
-  guild_id: "123456789"
-```
+### 設定步驟
+
+1. **安裝 Discord 外掛：**
+   ```bash
+   npm install -g @suzuke/agend-plugin-discord
+   ```
+
+2. **建立 Discord bot**，前往 [Discord Developer Portal](https://discord.com/developers/applications)：
+   - 建立新 Application → Bot
+   - 啟用 **Privileged Gateway Intents**：Presence Intent、Server Members Intent、Message Content Intent
+   - 產生邀請 URL，scope 選 `bot`，權限選 `Send Messages`、`Read Message History`、`Manage Channels`
+   - 邀請 bot 到你的伺服器
+
+3. **執行 quickstart**（Discord 推薦方式）：
+   ```bash
+   agend quickstart    # 選擇 "Discord"
+   ```
+   > **注意：** `agend init`（進階設定精靈）目前僅支援 Telegram。Discord 請使用 `agend quickstart`。
+
+4. **或手動設定** `fleet.yaml`：
+   ```yaml
+   channel:
+     type: discord
+     mode: topic           # 必填 — 不寫的話 bot 會靜默不啟動
+     bot_token_env: AGEND_DISCORD_TOKEN
+     group_id: "123456789012345678"   # Discord snowflake ID 必須加引號，避免精度丟失
+     access:
+       mode: locked
+       allowed_users:
+         - "your_discord_user_id"     # User ID 也要加引號
+   ```
+
+5. **設定 bot token**，寫入 `~/.agend/.env`：
+   ```
+   AGEND_DISCORD_TOKEN=your_bot_token_here
+   ```
+
+### 疑難排解
+
+- **Bot 不上線：** 確認 `fleet.yaml` 中有設定 `mode: topic`。沒有的話 adapter 會靜默不啟動。
+- **訊息內容是空的：** 到 Discord Developer Portal → Bot → Privileged Gateway Intents 啟用 **Message Content Intent**。
+- **ID 精度丟失：** YAML 中的 Discord ID（guild ID、user ID）務必加引號 — 它們是 64-bit snowflake，超過 JavaScript 整數精度。
+- **MCP 導致啟動慢：** 如果 backend CLI 因 MCP server 連線而啟動逾時，可在 `fleet.yaml` 增加 timeout：
+  ```yaml
+  defaults:
+    startup_timeout_ms: 60000   # 預設：25000 (25 秒)
+  ```
+- **`registerBotCommands` ETIMEDOUT：** 這是非致命錯誤 — bot polling 仍會正常啟動。在網路不穩時會發生。
+- **`working_directory` 找不到：** v1.19 起目錄會自動建立。如果遇到此錯誤，請更新到最新版本。
 
 ## 外部轉接器外掛系統 (External adapter plugin system)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -128,7 +128,16 @@ export function loadFleetConfig(configPath: string): FleetConfig {
   }
 
   return {
-    channel: parsed.channel,
+    channel: parsed.channel
+      ? (() => {
+          if (!parsed.channel.mode) {
+            throw new Error(
+              `fleet.yaml: channel.mode is required. Valid values: "topic" | "classic"`
+            );
+          }
+          return parsed.channel;
+        })()
+      : parsed.channel,
     project_roots: parsed.project_roots,
     defaults: fleetDefaults,
     instances,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1144,9 +1144,12 @@ export class Daemon extends EventEmitter {
     // Register with control client and wait for output + idle
     await this.controlClient?.registerWindow(windowId);
     if (this.controlClient) {
-      const hasOutput = await this.controlClient.waitForOutput(windowId, 15_000);
+      const total = this.config.startup_timeout_ms ?? 25_000;
+      const outputTimeout = Math.round(total * 0.6);
+      const idleTimeout = total - outputTimeout;
+      const hasOutput = await this.controlClient.waitForOutput(windowId, outputTimeout);
       if (!hasOutput) return false;
-      await this.controlClient.waitForIdle(windowId, 10_000);
+      await this.controlClient.waitForIdle(windowId, idleTimeout);
     } else {
       await new Promise(r => setTimeout(r, 10_000));
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,7 @@ export interface ChannelConfig {
   type: string;
   mode: "topic";
   bot_token_env: string;
-  group_id?: number;
+  group_id?: number | string;
   access: AccessConfig;
   options?: Record<string, unknown>;
   /** Override the Telegram Bot API root URL (e.g. for testing with a mock server). */
@@ -104,6 +104,8 @@ export interface InstanceConfig {
   worktree_source?: string;
   /** Workflow template: "builtin" (default), "file:path", inline string, or false to disable */
   workflow?: string | false;
+  /** Total startup timeout in ms for CLI backend (split 60/40 between output detection and idle wait). Default: 25000 */
+  startup_timeout_ms?: number;
 }
 
 export interface WebhookConfig {

--- a/src/web-api.ts
+++ b/src/web-api.ts
@@ -17,7 +17,7 @@ export interface WebApiContext {
   readonly dataDir: string;
   readonly sseClients: Set<ServerResponse>;
   readonly fleetConfig: {
-    channel?: { group_id?: number; mode?: string };
+    channel?: { group_id?: number | string; mode?: string };
     instances: Record<string, { topic_id?: number | string; working_directory: string; description?: string; display_name?: string }>;
     teams?: Record<string, { members: string[]; description?: string }>;
   } | null;
@@ -467,7 +467,7 @@ export function handleWebRequest(
         // Update channel settings
         if (body.channel && ch) {
           const update = body.channel as Record<string, unknown>;
-          if (update.group_id != null) (config.channel as Record<string, unknown>).group_id = Number(update.group_id);
+          if (update.group_id != null) (config.channel as Record<string, unknown>).group_id = update.group_id;
           if (update.access) (config.channel as Record<string, unknown>).access = update.access;
         }
         // Update defaults


### PR DESCRIPTION
Extracted from #17. Addresses the items flagged as cherry-pick candidates.

## Changes

### `startup_timeout_ms` configurable
Adds `startup_timeout_ms` to fleet.yaml (default 25 000 ms, 60/40 split between output detection and idle wait). Solves slow MCP server connection timeouts on first start.

### Discord snowflake precision
Changes `group_id` type to `number | string` and removes the `Number()` cast in `web-api.ts` that silently truncated 64-bit Discord snowflake IDs.

### `channel.mode` validation
Per review feedback on #17: `channel.mode` is now a required field. Missing value throws a clear validation error instead of silently defaulting to `"topic"`.

### Discord setup documentation
- Comprehensive Discord setup guide in `docs/features.md` (EN + zh-TW): plugin install, bot permissions, Gateway Intents, snowflake ID quoting reminder
- Documents `registerBotCommands ETIMEDOUT` as non-fatal
- Updates `docs/configuration.md` with `group_id` type and `startup_timeout_ms`
- Adds Discord note to README Quick Start

## What's NOT included
No ClassicBot mode, no routing changes, no fleet-manager changes.****