### PR TITLE
fix(discord): catch expired interaction errors to prevent daemon crash

### DIFF
--- a/plugins/agend-plugin-discord/src/discord-adapter.ts
+++ b/plugins/agend-plugin-discord/src/discord-adapter.ts
@@ -148,17 +148,23 @@ export class DiscordAdapter extends EventEmitter implements ChannelAdapter {
     });
 
     // Handle button interactions
+    // Trust boundary: deferUpdate() can throw DiscordAPIError[10062] if the
+    // interaction expires (>3s). Catch to prevent crashing the entire daemon.
     this.client.on("interactionCreate", async (interaction: Interaction) => {
-      if (!interaction.isButton()) return;
+      try {
+        if (!interaction.isButton()) return;
 
-      await interaction.deferUpdate();
+        await interaction.deferUpdate();
 
-      this.emit("callback_query", {
-        callbackData: interaction.customId,
-        chatId: this.guildId,
-        threadId: interaction.channelId,
-        messageId: interaction.message.id,
-      });
+        this.emit("callback_query", {
+          callbackData: interaction.customId,
+          chatId: this.guildId,
+          threadId: interaction.channelId,
+          messageId: interaction.message.id,
+        });
+      } catch (err) {
+        console.warn(`[discord] interactionCreate error (${(err as Error).message})`);
+      }
     });
 
     // Handle channel deletion (equivalent to topic_closed)


### PR DESCRIPTION
## Problem

`deferUpdate()` in the `interactionCreate` handler can throw `DiscordAPIError[10062]: Unknown interaction` when a Discord interaction expires (>3s response time). This uncaught exception crashes the entire AgEnD daemon process.

## Fix

Wrapped the `interactionCreate` handler in try-catch. Expired interaction errors are now logged as warnings instead of propagating as uncaught exceptions.

## Changes

`plugins/agend-plugin-discord/src/discord-adapter.ts` — 1 file, +16/-10