### PR TITLE
feat: WSL detection for install script + system memory display in agend ls

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import {
   rmSync,
   statSync,
 } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, totalmem, freemem } from "node:os";
 import { fileURLToPath } from "node:url";
 import { spawn, execSync, execFileSync } from "node:child_process";
 import { getAgendHome, getTmuxSocketName } from "./paths.js";
@@ -1458,6 +1458,11 @@ async function lsAction(opts: { json?: boolean }): Promise<void> {
         actStr
       );
     }
+
+    // System memory footer
+    const totalGB = totalmem() / (1024 ** 3);
+    const usedGB = (totalmem() - freemem()) / (1024 ** 3);
+    console.log(`\nSystem Memory: ${usedGB.toFixed(1)} / ${totalGB.toFixed(1)} GB`);
 }
 
 program

--- a/website/public/install.sh
+++ b/website/public/install.sh
@@ -49,6 +49,30 @@ esac
 
 info "$OS_NAME ($ARCH)"
 
+# ── WSL Detection ────────────────────────────────────────
+
+IS_WSL=false
+if [ "$OS" = "Linux" ] && grep -qiE "microsoft|WSL" /proc/version 2>/dev/null; then
+  IS_WSL=true
+  warn "WSL environment detected"
+
+  # Check if node resolves to a Windows binary
+  if command_exists node; then
+    NODE_PATH=$(which node)
+    if [[ "$NODE_PATH" == /mnt/c/* ]] || [[ "$NODE_PATH" == /mnt/d/* ]]; then
+      warn "Windows Node.js detected at $NODE_PATH — this causes issues in WSL"
+      warn "Will install a native Linux Node.js via nvm instead"
+      # Shadow the Windows node so the version check below triggers nvm install
+      node() { return 1; }
+      command_exists() { [[ "$1" != "node" ]] && command -v "$1" >/dev/null 2>&1 || return 1; }
+    fi
+  fi
+
+  echo -e "  ${DIM}Tip: To permanently hide Windows PATH in WSL, add to /etc/wsl.conf:${NC}"
+  echo -e "  ${DIM}  [interop]${NC}"
+  echo -e "  ${DIM}  appendWindowsPath=false${NC}"
+fi
+
 # Detect package manager
 PKG_MGR=""
 if command_exists brew; then
@@ -92,10 +116,27 @@ if [ "$NODE_OK" = false ]; then
   nvm use 22
   nvm alias default 22
 
+  # Restore command_exists if we shadowed it for WSL
+  if [ "$IS_WSL" = true ]; then
+    unset -f node 2>/dev/null || true
+    unset -f command_exists 2>/dev/null || true
+    command_exists() { command -v "$1" >/dev/null 2>&1; }
+  fi
+
   if ! command_exists node; then
     error "Failed to install Node.js. Please install manually: https://nodejs.org"
   fi
   info "Node.js $(node -v) installed via nvm"
+fi
+
+# Ensure nvm node is first in PATH on WSL
+if [ "$IS_WSL" = true ] && [ -d "${NVM_DIR:-$HOME/.nvm}" ]; then
+  export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+  [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+  NODE_PATH=$(which node 2>/dev/null || true)
+  if [[ "$NODE_PATH" == /mnt/c/* ]] || [[ "$NODE_PATH" == /mnt/d/* ]]; then
+    warn "Windows node still first in PATH — nvm node may not be active"
+  fi
 fi
 
 # ── Step 3: tmux ─────────────────────────────────────────

--- a/website/public/install.sh
+++ b/website/public/install.sh
@@ -58,9 +58,9 @@ if [ "$OS" = "Linux" ] && grep -qiE "microsoft|WSL" /proc/version 2>/dev/null; t
 
   # Check if node resolves to a Windows binary
   if command_exists node; then
-    NODE_PATH=$(which node)
-    if [[ "$NODE_PATH" == /mnt/c/* ]] || [[ "$NODE_PATH" == /mnt/d/* ]]; then
-      warn "Windows Node.js detected at $NODE_PATH — this causes issues in WSL"
+    NODE_BIN_PATH=$(command -v node)
+    if [[ "$NODE_BIN_PATH" == /mnt/[a-z]/* ]]; then
+      warn "Windows Node.js detected at $NODE_BIN_PATH — this causes issues in WSL"
       warn "Will install a native Linux Node.js via nvm instead"
       # Shadow the Windows node so the version check below triggers nvm install
       node() { return 1; }
@@ -133,8 +133,8 @@ fi
 if [ "$IS_WSL" = true ] && [ -d "${NVM_DIR:-$HOME/.nvm}" ]; then
   export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
   [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-  NODE_PATH=$(which node 2>/dev/null || true)
-  if [[ "$NODE_PATH" == /mnt/c/* ]] || [[ "$NODE_PATH" == /mnt/d/* ]]; then
+  NODE_BIN_PATH=$(command -v node 2>/dev/null || true)
+  if [[ "$NODE_BIN_PATH" == /mnt/[a-z]/* ]]; then
     warn "Windows node still first in PATH — nvm node may not be active"
   fi
 fi


### PR DESCRIPTION
## Changes

### 1. WSL Detection in Install Script (install.sh)
- Detect WSL via `/proc/version`
- Detect Windows node in PATH (`/mnt/[a-z]/*`) and force nvm installation
- Post-install PATH verification ensures nvm node takes priority
- Suggest `appendWindowsPath=false` in `/etc/wsl.conf`
- Non-WSL Linux completely unaffected

### 2. System Memory Display in `agend ls`
- Added footer: `System Memory: X.X / Y.Y GB` (used / total)
- Uses `os.totalmem()` / `os.freemem()` — cross-platform, zero overhead
- JSON mode unaffected

Files: `website/public/install.sh`, `src/cli.ts`