### PR TITLE
feat: show Kiro CLI context usage in agend ls

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1391,7 +1391,7 @@ async function lsAction(opts: { json?: boolean }): Promise<void> {
       if (context == null) {
         try {
           const pane = execFileSync("tmux", tmuxArgs([
-            "capture-pane", "-t", `agend:${name}`, "-p"
+            "capture-pane", "-t", `${sessionName}:${name}`, "-p"
           ]), { encoding: "utf-8", timeout: 2000 });
           const m = pane.match(/(\d+)%\s*!>\s*$/m);
           if (m) context = parseInt(m[1], 10);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1393,7 +1393,8 @@ async function lsAction(opts: { json?: boolean }): Promise<void> {
           const pane = execFileSync("tmux", tmuxArgs([
             "capture-pane", "-t", `${sessionName}:${name}`, "-p"
           ]), { encoding: "utf-8", timeout: 2000 });
-          const m = pane.match(/(\d+)%\s*!>\s*$/m);
+          // Classic mode: "X% !>" | TUI mode: "◔ X%"
+          const m = pane.match(/(\d+)%\s*!>\s*$/m) || pane.match(/◔\s*(\d+)%/);
           if (m) context = parseInt(m[1], 10);
         } catch { /* tmux capture failed */ }
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1387,6 +1387,17 @@ async function lsAction(opts: { json?: boolean }): Promise<void> {
         }
       } catch { /* ignore */ }
 
+      // Fallback: capture context from tmux pane (e.g. Kiro CLI shows "X% !>")
+      if (context == null) {
+        try {
+          const pane = execFileSync("tmux", tmuxArgs([
+            "capture-pane", "-t", `agend:${name}`, "-p"
+          ]), { encoding: "utf-8", timeout: 2000 });
+          const m = pane.match(/(\d+)%\s*!>\s*$/m);
+          if (m) context = parseInt(m[1], 10);
+        } catch { /* tmux capture failed */ }
+      }
+
       // Memory: sum RSS of pane process tree
       let memMb: number | null = null;
       const panePid = pidByName.get(name);


### PR DESCRIPTION
## Problem
`agend ls` shows `-` for Kiro CLI context usage because Kiro doesn't write `statusline.json`.

## Fix
Fallback: when `statusline.json` has no context data, capture tmux pane and parse context percentage.

Supports both Kiro modes:
- Classic: `8% !>` → regex `(\d+)%\s*!>`
- TUI: `◔ 1%` → regex `◔\s*(\d+)%`

Graceful degradation — capture failure shows `-`.

File: `src/cli.ts`