### PR TITLE
feat: WSL detection for install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ AgEnD (**Agent Engineering Daemon**) turns your Telegram or Discord into a comma
 
 ```bash
 # Option A: One-line install (Linux / macOS / WSL)
-curl -fsSL https://raw.githubusercontent.com/suzuke/AgEnD/main/website/public/install.sh | bash
+curl -fsSL https://suzuke.github.io/AgEnD/install.sh | bash
 
 # Option B: Manual install
 npm install -g @suzuke/agend    # 1. Install
@@ -123,7 +123,7 @@ graph LR
 > [interop]
 > appendWindowsPath=false
 > ```
-> Then restart WSL (`wsl --shutdown`). Install with: `curl -fsSL https://raw.githubusercontent.com/suzuke/AgEnD/main/website/public/install.sh | bash`
+> Then restart WSL (`wsl --shutdown`). Install with: `curl -fsSL https://suzuke.github.io/AgEnD/install.sh | bash`
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ graph LR
 
 > **⚠️** All CLI backends run with `--dangerously-skip-permissions` (or equivalent). See [Security](SECURITY.md).
 
+> **WSL (Windows Subsystem for Linux):** Fully supported. The install script auto-detects WSL and avoids using Windows `node.exe` from PATH. If you encounter PATH issues, add to `/etc/wsl.conf`:
+> ```ini
+> [interop]
+> appendWindowsPath=false
+> ```
+> Then restart WSL (`wsl --shutdown`). Install with: `curl -fsSL https://raw.githubusercontent.com/suzuke/AgEnD/main/website/public/install.sh | bash`
+
 ## Documentation
 
 - [Features](docs/features.md) — detailed feature documentation

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ AgEnD (**Agent Engineering Daemon**) turns your Telegram or Discord into a comma
 ## Quick Start
 
 ```bash
+# Option A: One-line install (Linux / macOS / WSL)
+curl -fsSL https://raw.githubusercontent.com/suzuke/AgEnD/main/website/public/install.sh | bash
+
+# Option B: Manual install
 npm install -g @suzuke/agend    # 1. Install
 agend quickstart                # 2. Setup — bot token, backend, done
 agend fleet start               # 3. Launch your fleet 🎉

--- a/website/public/install.sh
+++ b/website/public/install.sh
@@ -49,6 +49,30 @@ esac
 
 info "$OS_NAME ($ARCH)"
 
+# ── WSL Detection ────────────────────────────────────────
+
+IS_WSL=false
+if [ "$OS" = "Linux" ] && grep -qiE "microsoft|WSL" /proc/version 2>/dev/null; then
+  IS_WSL=true
+  warn "WSL environment detected"
+
+  # Check if node resolves to a Windows binary
+  if command_exists node; then
+    NODE_BIN_PATH=$(command -v node)
+    if [[ "$NODE_BIN_PATH" == /mnt/[a-z]/* ]]; then
+      warn "Windows Node.js detected at $NODE_BIN_PATH — this causes issues in WSL"
+      warn "Will install a native Linux Node.js via nvm instead"
+      # Shadow the Windows node so the version check below triggers nvm install
+      node() { return 1; }
+      command_exists() { [[ "$1" != "node" ]] && command -v "$1" >/dev/null 2>&1 || return 1; }
+    fi
+  fi
+
+  echo -e "  ${DIM}Tip: To permanently hide Windows PATH in WSL, add to /etc/wsl.conf:${NC}"
+  echo -e "  ${DIM}  [interop]${NC}"
+  echo -e "  ${DIM}  appendWindowsPath=false${NC}"
+fi
+
 # Detect package manager
 PKG_MGR=""
 if command_exists brew; then
@@ -92,10 +116,27 @@ if [ "$NODE_OK" = false ]; then
   nvm use 22
   nvm alias default 22
 
+  # Restore command_exists if we shadowed it for WSL
+  if [ "$IS_WSL" = true ]; then
+    unset -f node 2>/dev/null || true
+    unset -f command_exists 2>/dev/null || true
+    command_exists() { command -v "$1" >/dev/null 2>&1; }
+  fi
+
   if ! command_exists node; then
     error "Failed to install Node.js. Please install manually: https://nodejs.org"
   fi
   info "Node.js $(node -v) installed via nvm"
+fi
+
+# Ensure nvm node is first in PATH on WSL
+if [ "$IS_WSL" = true ] && [ -d "${NVM_DIR:-$HOME/.nvm}" ]; then
+  export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+  [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+  NODE_BIN_PATH=$(command -v node 2>/dev/null || true)
+  if [[ "$NODE_BIN_PATH" == /mnt/[a-z]/* ]]; then
+    warn "Windows node still first in PATH — nvm node may not be active"
+  fi
 fi
 
 # ── Step 3: tmux ─────────────────────────────────────────


### PR DESCRIPTION
## Problem

On WSL, `install.sh` may use Windows node.exe from PATH (`/mnt/c/...`), causing build failures. Also, README lacked one-line install instructions and WSL guidance.

## Fix

### install.sh — WSL Detection
- Detect WSL via `/proc/version`
- Detect Windows node in PATH (`/mnt/[a-z]/*`) and force nvm installation
- Post-install PATH verification ensures nvm node takes priority
- Suggest `appendWindowsPath=false` in `/etc/wsl.conf`
- Non-WSL Linux completely unaffected

### README.md — Documentation
- Added one-line install option to Quick Start: `curl -fsSL https://suzuke.github.io/AgEnD/install.sh | bash`
- Added WSL support section in Requirements with setup tips

Files: `website/public/install.sh`, `README.md`