### PR TITLE
feat: show system memory usage in agend ls

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import {
   rmSync,
   statSync,
 } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, totalmem, freemem } from "node:os";
 import { fileURLToPath } from "node:url";
 import { spawn, execSync, execFileSync } from "node:child_process";
 import { getAgendHome, getTmuxSocketName } from "./paths.js";
@@ -1458,6 +1458,11 @@ async function lsAction(opts: { json?: boolean }): Promise<void> {
         actStr
       );
     }
+
+    // System memory footer
+    const totalGB = totalmem() / (1024 ** 3);
+    const usedGB = (totalmem() - freemem()) / (1024 ** 3);
+    console.log(`\nSystem Memory: ${usedGB.toFixed(1)} / ${totalGB.toFixed(1)} GB`);
 }
 
 program


### PR DESCRIPTION
## Problem
No visibility into system memory usage when running a fleet of agents.

## Fix
Added footer to `agend ls`: `System Memory: X.X / Y.Y GB` (used / total)
- Uses `os.totalmem()` / `os.freemem()` — cross-platform, zero overhead
- JSON mode unaffected

File: `src/cli.ts`