### PR TITLE
fix: audit follow-ups (P3.2 / P2.6 / P3.7)

### DIFF
--- a/docs/fix-plan.md
+++ b/docs/fix-plan.md
@@ -10,10 +10,10 @@
 
 | Phase | 範圍 | 狀態 | 分支 |
 |---|---|---|---|
-| Phase 1 | 安全邊界 | ✅ 完成 | `fix/phase-1-security` |
-| Phase 2 | 可靠性核心 | ⬜ | - |
-| Phase 3 | 外部介面治理 | ⬜ | - |
-| Phase 4 | KISS 與測試 hygiene | ⬜ | - |
+| Phase 1 | 安全邊界 | ✅ 完成 | `fix/phase-1-security` (merged #33) |
+| Phase 2 | 可靠性核心 | 🟦 5/8 | `fix/audit-followups` (P2.6) |
+| Phase 3 | 外部介面治理 | 🟦 2/8 | `fix/audit-followups` (P3.2, P3.7) |
+| Phase 4 | KISS 與測試 hygiene | 🟦 部分 | - |
 
 ---
 
@@ -75,16 +75,16 @@
 
 ## Phase 2 — 可靠性核心
 
-| ID | 項目 | 狀態 |
-|---|---|---|
-| P2.1 | TmuxControlClient reconnect 清 pane map | ⬜ |
-| P2.2 | Cost guard rotation reset emitted flags | ⬜ |
-| P2.3 | Scheduler catch-up 機制 | ⬜ |
-| P2.4 | TranscriptMonitor 防重入 | ⬜ |
-| P2.5 | SSE client 清理 | ⬜ |
-| P2.6 | Topic archiver 持久化 | ⬜ |
-| P2.7 | 啟動 waitForIdle 取代 setTimeout | ⬜ |
-| P2.8 | msUntilMidnight DST 修復 | ⬜ |
+| ID | 項目 | 狀態 | Commit |
+|---|---|---|---|
+| P2.1 | TmuxControlClient reconnect 清 pane map | ⬜ | - |
+| P2.2 | Cost guard rotation reset emitted flags | ✅ | (pre-existing in `cost-guard.ts:119-121` `trackers.clear()` 重建 tracker) |
+| P2.3 | Scheduler catch-up 機制 | ⬜ | - |
+| P2.4 | TranscriptMonitor 防重入 | ⬜ | - |
+| P2.5 | SSE client 清理 | ✅ | (pre-existing in `web-api.ts:237-240` `req.on("close")`) |
+| P2.6 | Topic archiver 持久化 | ✅ | `f134a66` |
+| P2.7 | 啟動 waitForIdle 取代 setTimeout | ✅ | (pre-existing in `daemon.ts:1267-1269`) |
+| P2.8 | msUntilMidnight DST 修復 | ✅ | (pre-existing in `cost-guard.ts:16-23` `setHours(24,0,0,0)` tz-aware) |
 
 詳細修法見原 review 彙整。
 
@@ -92,29 +92,29 @@
 
 ## Phase 3 — 外部介面治理
 
-| ID | 項目 | 狀態 |
-|---|---|---|
-| P3.1 | Webhook HMAC + retry 策略 | ⬜ |
-| P3.2 | Telegram 409 polling 上限 | ⬜ |
-| P3.3 | Telegram apiRoot 白名單 | ⬜ |
-| P3.4 | STT 隱私開關（opt-in） | ⬜ |
-| P3.5 | CORS 收緊 + Bearer header | ⬜ |
-| P3.6 | `/update` 安全化（版本鎖、回滾、二次確認） | ⬜ |
-| P3.7 | IPC 單行上限 10MB → 1MB | ⬜ |
-| P3.8 | MessageQueue flood control reset | ⬜ |
+| ID | 項目 | 狀態 | Commit |
+|---|---|---|---|
+| P3.1 | Webhook HMAC + retry 策略 | ⬜ | - |
+| P3.2 | Telegram 409 polling 上限 | ✅ | `c67f776` |
+| P3.3 | Telegram apiRoot 白名單 | ⬜ | - |
+| P3.4 | STT 隱私開關（opt-in） | ⬜ | - |
+| P3.5 | CORS 收緊 + Bearer header | ⬜ | - |
+| P3.6 | `/update` 安全化（版本鎖、回滾、二次確認） | ⬜ | - |
+| P3.7 | IPC 單行上限 10MB → 1MB | ✅ | `d446384` |
+| P3.8 | MessageQueue flood control reset | ⬜ | - |
 
 ---
 
 ## Phase 4 — KISS 與測試 hygiene
 
-| ID | 項目 | 狀態 |
-|---|---|---|
-| P4.1 | 拆檔（daemon.ts / fleet-manager.ts / cli.ts） | ⬜ |
-| P4.2 | `handleToolCall` 路由抽取 | ⬜ |
-| P4.3 | `access-path` 驗證 | ⬜ |
-| P4.4 | `.env` 權限 + docs 同步 + validateTimezone 單一化 | ⬜ |
-| P4.5 | 小修補集合（cost-guard tiebreaker / logger rotation / MD5→SHA1 / sleep→setTimeout / FNV pane hash / 根目錄清理 / deprecated getter 遷移） | ⬜ |
-| P4.6 | 測試 hygiene（搬 e2e / 改 waitFor / 強 assert / 補覆蓋） | ⬜ |
+| ID | 項目 | 狀態 | Commit |
+|---|---|---|---|
+| P4.1 | 拆檔（daemon.ts / fleet-manager.ts / cli.ts） | ⬜ | fleet-manager 仍 2819 行 |
+| P4.2 | `handleToolCall` 路由抽取 | 🟦 部分 | `outboundHandlers` Map + `routeToolCall` 已抽出，但 `daemon.ts:820-1002` 主分流仍是 180 行 if-chain |
+| P4.3 | `access-path` 驗證 | 🟦 部分 | `tool-router.ts assertSendable()` 有覆蓋 reply tools；`access-manager` 仍缺路徑驗證 |
+| P4.4 | `.env` 權限 + docs 同步 + validateTimezone 單一化 | ⬜ | `validateTimezone` 仍重複定義於 `config.ts` 與 `scheduler/scheduler.ts` |
+| P4.5 | 小修補集合 | ⬜ | `paths.ts:15,27` 仍用 `createHash("md5")`；無 logger rotation；無 cost-guard tiebreaker；「根目錄 test-perm-detect.ts」誤判（已在 .gitignore） |
+| P4.6 | 測試 hygiene | ✅ | e2e 已在 `e2e/tests/`；單元測試使用 `waitFor`；無已知 hygiene 問題 |
 
 ---
 
@@ -129,12 +129,17 @@
 
 ## Handover — 給下一個 Session
 
-**當前狀態**（最後更新：2026-04-18，Phase 1 完成）：
+**當前狀態**（最後更新：2026-04-20，audit-followups 三項完成）：
 
-- 當前 worktree：`.worktrees/fix-phase-1`（branch `fix/phase-1-security`，領先 main 9 commits）
-- Phase 1 ✅ 完成：P1.1–P1.8 全部 commit；`npx tsc --noEmit` 綠、`npx vitest run` 404/405（唯一 fail 為 `tests/context-guardian.test.ts` 的 watchFile 計時 flake，單跑通過，與本 Phase 改動無關）
-- 下一個 Phase：Phase 2（可靠性核心）— 開新 worktree `fix/phase-2-reliability`，從 P2.1 TmuxControlClient reconnect 清 pane map 開始
-- 待人工確認：Phase 1 需 review / open PR 合回 main；Phase 2 應從合回後的 main 分支出
+- Phase 1 ✅ 已合回 main（PR #33）
+- 當前 worktree：`.worktrees/fix-audit-followups`（branch `fix/audit-followups`，領先 main 3 commits）
+- 本輪交付（cross-phase）：
+  - `c67f776` P3.2 Telegram 409 polling 上限（30 retries cap + 測試）
+  - `f134a66` P2.6 Topic archiver 持久化（`<dataDir>/archived-topics.json` + 4 個測試）
+  - `d446384` P3.7 IPC 單行上限 10MB → 1MB（+ overflow 測試）
+- 驗證：`npx tsc --noEmit` 綠；`npx vitest run` 411/411 全綠
+- 同時於本輪重新驗證 codebase，確認 P2.2 / P2.5 / P2.7 / P2.8 / P4.6 已在過去某時點完成（subagent 初判遺漏，本文件已更新）
+- 下一輪建議優先：**P2.1 (pane map)** → **P2.4 (TranscriptMonitor 重入)** → **P2.3 (Scheduler catch-up)** → **P3.5 (CORS + Bearer)** → **P3.3 (apiRoot 白名單)**
 
 ### Phase 1 commits（按時間由新到舊）
 

--- a/src/channel/adapters/telegram.ts
+++ b/src/channel/adapters/telegram.ts
@@ -261,10 +261,11 @@ export class TelegramAdapter extends EventEmitter implements ChannelAdapter {
     });
 
     // 409 Conflict = another getUpdates consumer is active (official plugin zombie,
-    // or second Claude Code instance). Retry with backoff until the slot frees up.
-    // Pattern from official telegram plugin.
+    // or second Claude Code instance). Retry with backoff, but cap attempts so a
+    // permanently-stuck conflict does not loop forever.
+    const MAX_409_RETRIES = 30; // ~7 min total at 15s ceiling
     void (async () => {
-      for (let attempt = 1; ; attempt++) {
+      for (let attempt = 1; attempt <= MAX_409_RETRIES; attempt++) {
         try {
           await this.bot.start({
             drop_pending_updates: attempt === 1,
@@ -275,6 +276,12 @@ export class TelegramAdapter extends EventEmitter implements ChannelAdapter {
           return; // bot.stop() was called — clean exit
         } catch (err) {
           if (err instanceof GrammyError && err.error_code === 409) {
+            if (attempt >= MAX_409_RETRIES) {
+              this.emit("error", new Error(
+                `Telegram polling: 409 conflict persisted after ${MAX_409_RETRIES} attempts; giving up`,
+              ));
+              return;
+            }
             const delay = Math.min(1000 * attempt, 15000);
             this.emit("polling_conflict", { attempt, delay });
             await new Promise(r => setTimeout(r, delay));

--- a/src/channel/ipc-bridge.ts
+++ b/src/channel/ipc-bridge.ts
@@ -15,7 +15,11 @@ function encode(msg: unknown): string {
   return JSON.stringify(msg) + "\n";
 }
 
-const MAX_LINE_BUFFER = 10 * 1024 * 1024; // 10 MB
+// 1 MB is well above any legitimate IPC payload (tool calls/responses,
+// schedule/decision/task lists). The previous 10 MB ceiling was loose
+// DoS protection — a runaway producer could buffer 10 MB per client
+// before being dropped.
+const MAX_LINE_BUFFER = 1 * 1024 * 1024;
 
 function makeLineParser(onMessage: (msg: unknown) => void, onOverflow?: () => void) {
   let buf = "";

--- a/src/topic-archiver.ts
+++ b/src/topic-archiver.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import type { FleetConfig } from "./types.js";
 import type { ChannelAdapter } from "./channel/types.js";
 import type { Logger } from "./logger.js";
@@ -6,6 +8,7 @@ export interface ArchiverContext {
   readonly fleetConfig: FleetConfig | null;
   readonly adapter: ChannelAdapter | null;
   readonly logger: Logger;
+  readonly dataDir: string;
   getInstanceStatus(name: string): "running" | "stopped" | "crashed";
   lastActivityMs(name: string): number;
   setTopicIcon(name: string, state: "green" | "blue" | "red" | "remove"): void;
@@ -14,15 +17,43 @@ export interface ArchiverContext {
 
 /**
  * Manages automatic archival (close) and reopening of idle forum topics.
+ *
+ * Archived state is persisted to `<dataDir>/archived-topics.json` so a daemon
+ * restart does not re-archive (or re-message) topics that were already closed.
  */
 export class TopicArchiver {
   private archived = new Set<string>();
   private timer: ReturnType<typeof setInterval> | null = null;
+  private readonly statePath: string;
 
   static readonly IDLE_MS = 24 * 60 * 60 * 1000; // 24 hours
   private static readonly POLL_MS = 30 * 60_000;  // check every 30 minutes
 
-  constructor(private ctx: ArchiverContext) {}
+  constructor(private ctx: ArchiverContext) {
+    this.statePath = join(ctx.dataDir, "archived-topics.json");
+    this.load();
+  }
+
+  private load(): void {
+    if (!existsSync(this.statePath)) return;
+    try {
+      const arr: unknown = JSON.parse(readFileSync(this.statePath, "utf-8"));
+      if (!Array.isArray(arr)) return;
+      for (const id of arr) {
+        if (typeof id === "string") this.archived.add(id);
+      }
+    } catch (err) {
+      this.ctx.logger.warn({ err, path: this.statePath }, "Failed to load archived-topics state");
+    }
+  }
+
+  private save(): void {
+    try {
+      writeFileSync(this.statePath, JSON.stringify([...this.archived]));
+    } catch (err) {
+      this.ctx.logger.warn({ err, path: this.statePath }, "Failed to save archived-topics state");
+    }
+  }
 
   /** Is this topic currently archived? */
   isArchived(topicId: string): boolean {
@@ -65,6 +96,7 @@ export class TopicArchiver {
 
       this.ctx.logger.info({ name, topicId, idleHours: Math.round((now - last) / 3600000) }, "Archiving idle topic");
       this.archived.add(topicIdStr);
+      this.save();
       this.ctx.setTopicIcon(name, "remove");
       await this.ctx.adapter.closeForumTopic(topicId);
     }
@@ -74,6 +106,7 @@ export class TopicArchiver {
   async reopen(topicId: string, instanceName: string): Promise<void> {
     if (!this.archived.has(topicId)) return;
     this.archived.delete(topicId);
+    this.save();
 
     if (this.ctx.adapter?.reopenForumTopic) {
       await this.ctx.adapter.reopenForumTopic(topicId);

--- a/src/topic-archiver.ts
+++ b/src/topic-archiver.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { FleetConfig } from "./types.js";
 import type { ChannelAdapter } from "./channel/types.js";
@@ -48,8 +48,12 @@ export class TopicArchiver {
   }
 
   private save(): void {
+    // Atomic write: tmp + rename so a crash mid-write cannot leave a
+    // truncated JSON that load() would reject.
+    const tmp = `${this.statePath}.tmp`;
     try {
-      writeFileSync(this.statePath, JSON.stringify([...this.archived]));
+      writeFileSync(tmp, JSON.stringify([...this.archived]));
+      renameSync(tmp, this.statePath);
     } catch (err) {
       this.ctx.logger.warn({ err, path: this.statePath }, "Failed to save archived-topics state");
     }

--- a/tests/channel/adapters/telegram.test.ts
+++ b/tests/channel/adapters/telegram.test.ts
@@ -80,7 +80,20 @@ vi.mock("grammy", () => {
   // Expose handlers map so tests can fire them
   (globalThis as Record<string, unknown>).__grammyHandlers = handlers;
 
-  return { Bot: MockBot, InputFile: MockInputFile, InlineKeyboard: MockInlineKeyboard };
+  class MockGrammyError extends Error {
+    error_code: number;
+    constructor(message: string, error_code: number) {
+      super(message);
+      this.error_code = error_code;
+    }
+  }
+
+  return {
+    Bot: MockBot,
+    InputFile: MockInputFile,
+    InlineKeyboard: MockInlineKeyboard,
+    GrammyError: MockGrammyError,
+  };
 });
 
 // ── Imports after mock ────────────────────────────────────────────────────
@@ -175,6 +188,34 @@ describe("TelegramAdapter", () => {
   it("stop() stops the queue and bot", async () => {
     await adapter.start();
     await expect(adapter.stop()).resolves.toBeUndefined();
+  });
+
+  it("gives up after MAX_409_RETRIES on persistent 409 conflict", async () => {
+    vi.useFakeTimers();
+    try {
+      const grammy = await import("grammy");
+      const GrammyError = (grammy as unknown as { GrammyError: new (m: string, c: number) => Error & { error_code: number } }).GrammyError;
+      const bot = (adapter as unknown as { bot: { start: ReturnType<typeof vi.fn> } }).bot;
+      bot.start = vi.fn(() => Promise.reject(new GrammyError("conflict", 409)));
+
+      const errors: Error[] = [];
+      const conflicts: number[] = [];
+      adapter.on("error", (e: Error) => errors.push(e));
+      adapter.on("polling_conflict", ({ attempt }: { attempt: number }) => conflicts.push(attempt));
+
+      await adapter.start();
+      // Drain the 409 backoff loop (cap is 30 retries; max delay is 15s each)
+      for (let i = 0; i < 35; i++) {
+        await vi.advanceTimersByTimeAsync(15_000);
+      }
+
+      expect(bot.start).toHaveBeenCalledTimes(30);
+      expect(conflicts).toHaveLength(29); // emitted before each delay; final attempt skips delay
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toMatch(/giving up/);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   // ── sendText ─────────────────────────────────────────────────────────────

--- a/tests/channel/ipc-bridge.test.ts
+++ b/tests/channel/ipc-bridge.test.ts
@@ -67,6 +67,31 @@ describe("IPC Bridge", () => {
     await client.connect(); // should work
   });
 
+  it("drops client when a single line exceeds the 1 MB buffer cap", async () => {
+    tmpDir = join(tmpdir(), `ccd-ipc-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    const sockPath = join(tmpDir, "test.sock");
+
+    server = new IpcServer(sockPath);
+    const received: unknown[] = [];
+    server.on("message", (msg) => received.push(msg));
+    await server.listen();
+
+    client = new IpcClient(sockPath);
+    let disconnected = false;
+    client.on("disconnect", () => { disconnected = true; });
+    await client.connect();
+
+    // Server-side: write a payload exceeding 1 MB on a single line (no \n)
+    // to trigger the line-parser overflow path.
+    const huge = "x".repeat(1_100_000);
+    server.broadcast({ type: "evil", payload: huge });
+
+    await new Promise(r => setTimeout(r, 200));
+    expect(received).toHaveLength(0); // overflow before parse
+    expect(disconnected).toBe(true);  // client socket destroyed
+  });
+
   it("rejects socket path exceeding OS limit", async () => {
     tmpDir = join(tmpdir(), `ccd-ipc-${Date.now()}`);
     mkdirSync(tmpDir, { recursive: true });

--- a/tests/topic-archiver.test.ts
+++ b/tests/topic-archiver.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { TopicArchiver, type ArchiverContext } from "../src/topic-archiver.js";
+import type { FleetConfig } from "../src/types.js";
+
+function silentLogger() {
+  return { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(), trace: vi.fn() };
+}
+
+function makeCtx(overrides: Partial<ArchiverContext> = {}): ArchiverContext {
+  return {
+    fleetConfig: null,
+    adapter: null,
+    logger: silentLogger() as unknown as ArchiverContext["logger"],
+    dataDir: "",
+    getInstanceStatus: () => "running",
+    lastActivityMs: () => 0,
+    setTopicIcon: () => {},
+    touchActivity: () => {},
+    ...overrides,
+  };
+}
+
+describe("TopicArchiver persistence", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `archiver-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("persists archived topics across restart", async () => {
+    const closeForumTopic = vi.fn().mockResolvedValue(undefined);
+    const fleetConfig = {
+      instances: {
+        worker: { topic_id: 42, general_topic: false },
+      },
+    } as unknown as FleetConfig;
+
+    // First run: archive an idle topic
+    const ctx1 = makeCtx({
+      dataDir: tmpDir,
+      fleetConfig,
+      adapter: { closeForumTopic } as unknown as ArchiverContext["adapter"],
+      lastActivityMs: () => Date.now() - (TopicArchiver.IDLE_MS + 1000),
+    });
+    const archiver1 = new TopicArchiver(ctx1);
+    await archiver1.archiveIdle();
+    expect(archiver1.isArchived("42")).toBe(true);
+    expect(closeForumTopic).toHaveBeenCalledTimes(1);
+
+    // State file should exist on disk
+    const statePath = join(tmpDir, "archived-topics.json");
+    expect(existsSync(statePath)).toBe(true);
+    expect(JSON.parse(readFileSync(statePath, "utf-8"))).toEqual(["42"]);
+
+    // Second run: fresh instance loads state, does NOT re-archive
+    const ctx2 = makeCtx({
+      dataDir: tmpDir,
+      fleetConfig,
+      adapter: { closeForumTopic } as unknown as ArchiverContext["adapter"],
+      lastActivityMs: () => Date.now() - (TopicArchiver.IDLE_MS + 1000),
+    });
+    const archiver2 = new TopicArchiver(ctx2);
+    expect(archiver2.isArchived("42")).toBe(true); // remembered
+    await archiver2.archiveIdle();
+    expect(closeForumTopic).toHaveBeenCalledTimes(1); // not called again
+  });
+
+  it("removes id from state on reopen", async () => {
+    const reopenForumTopic = vi.fn().mockResolvedValue(undefined);
+    const ctx = makeCtx({
+      dataDir: tmpDir,
+      adapter: { reopenForumTopic } as unknown as ArchiverContext["adapter"],
+    });
+    const archiver = new TopicArchiver(ctx);
+    // Seed state directly via archiveIdle path
+    (archiver as unknown as { archived: Set<string> }).archived.add("99");
+    (archiver as unknown as { save: () => void }).save();
+
+    await archiver.reopen("99", "worker");
+    expect(archiver.isArchived("99")).toBe(false);
+
+    // Re-load fresh instance — should NOT have 99
+    const archiver2 = new TopicArchiver(ctx);
+    expect(archiver2.isArchived("99")).toBe(false);
+  });
+
+  it("tolerates missing state file on first start", () => {
+    const ctx = makeCtx({ dataDir: tmpDir });
+    expect(() => new TopicArchiver(ctx)).not.toThrow();
+  });
+
+  it("tolerates corrupted state file", () => {
+    const statePath = join(tmpDir, "archived-topics.json");
+    writeFileSync(statePath, "not valid json{{");
+    const ctx = makeCtx({ dataDir: tmpDir });
+    const archiver = new TopicArchiver(ctx);
+    expect(archiver.isArchived("anything")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Cross-phase batch from `docs/fix-plan.md` after re-verifying Phase 2-4 status against the codebase:

- **P3.2** Telegram 409 polling — cap retries at 30 (~7 min total) and emit a final error instead of looping forever every 15s
- **P2.6** TopicArchiver — persist archived topic ids to `<dataDir>/archived-topics.json` so a daemon restart does not re-archive topics users already reopened
- **P3.7** IPC bridge — single-line buffer cap from 10 MB → 1 MB (real payloads are < 100 KB; 10x smaller DoS window)
- **docs(fix-plan)** record commits + reclassify several P2/P4 items based on actual code state

## Verified during review

`P2.2`, `P2.5`, `P2.7`, `P2.8`, `P4.6` were already fixed in the codebase but still marked ⬜ in fix-plan.md. Now back-marked ✅. `P4.2` and `P4.3` reclassified as 🟦 partial (handleToolCall main body still 180-line if-chain; access-manager still lacks path validation). `P4.5` "root test-perm-detect.ts" was a false positive — already in `.gitignore`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` 411/411 pass (6 new tests added)
- [ ] Smoke test daemon restart preserves archived-topics state (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)