### PR TITLE
fix(phase-2): reliability + access boundary (P2.1/P2.4/P2.3/P3.5/P3.3)

### DIFF
--- a/src/channel/adapters/telegram.ts
+++ b/src/channel/adapters/telegram.ts
@@ -28,6 +28,44 @@ export interface TelegramAdapterOptions {
   apiRoot?: string;
 }
 
+/**
+ * Whitelist of legitimate Telegram API roots. Misconfiguring `apiRoot`
+ * (or having it set by an attacker via a config file write) would leak
+ * the bot token — every API call sends the token in the path. Only the
+ * official endpoint and loopback (E2E mock servers) are allowed.
+ */
+const TELEGRAM_API_HOST_ALLOWLIST = new Set([
+  "api.telegram.org",
+  "localhost",
+  "127.0.0.1",
+  "::1",
+]);
+
+export function validateTelegramApiRoot(apiRoot: string): void {
+  let url: URL;
+  try {
+    url = new URL(apiRoot);
+  } catch {
+    throw new Error(`Invalid telegram_api_root URL: ${apiRoot}`);
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error(`telegram_api_root must use http(s): ${apiRoot}`);
+  }
+  // http:// only allowed for loopback (mock servers); production must be https.
+  // URL.hostname wraps IPv6 in brackets ("[::1]") — strip them for allowlist match.
+  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (!TELEGRAM_API_HOST_ALLOWLIST.has(host)) {
+    throw new Error(
+      `telegram_api_root host "${host}" is not in the allowlist ` +
+      `(${[...TELEGRAM_API_HOST_ALLOWLIST].join(", ")}). ` +
+      `Sending the bot token to an arbitrary host would leak credentials.`,
+    );
+  }
+  if (url.protocol === "http:" && host === "api.telegram.org") {
+    throw new Error("telegram_api_root must use https for api.telegram.org");
+  }
+}
+
 export class TelegramAdapter extends EventEmitter implements ChannelAdapter {
   readonly type = "telegram";
   readonly topology = "topics" as const;
@@ -45,6 +83,7 @@ export class TelegramAdapter extends EventEmitter implements ChannelAdapter {
     this.id = opts.id;
     this.accessManager = opts.accessManager;
     this.inboxDir = opts.inboxDir;
+    if (opts.apiRoot) validateTelegramApiRoot(opts.apiRoot);
     this.apiRoot = (opts.apiRoot ?? "https://api.telegram.org").replace(/\/+$/, "");
 
     mkdirSync(this.inboxDir, { recursive: true });

--- a/src/fleet-manager.ts
+++ b/src/fleet-manager.ts
@@ -451,6 +451,7 @@ export class FleetManager implements FleetContext, LifecycleContext, ArchiverCon
         (schedule) => this.handleScheduleTrigger(schedule),
         schedulerConfig,
         (name) => this.fleetConfig?.instances?.[name] != null,
+        this.logger,
       );
       this.scheduler.init();
       this.logger.info("Scheduler initialized");

--- a/src/fleet-manager.ts
+++ b/src/fleet-manager.ts
@@ -42,6 +42,35 @@ import { handleAgentRequest, type AgentEndpointContext } from "./agent-endpoint.
 
 import { getTmuxSession } from "./config.js";
 
+/**
+ * Extract a web token from a request, accepting (in order):
+ *   1. `?token=` query string
+ *   2. `Authorization: Bearer <token>` header (standard)
+ *   3. `X-Agend-Token: <token>` header (legacy compatibility)
+ *
+ * Centralized so the CLI/SDK callers can rely on Bearer alongside the
+ * existing query/header schemes without duplicating parsing.
+ */
+export function extractWebToken(
+  parsedUrl: URL,
+  headers: Record<string, string | string[] | undefined>,
+): string | null {
+  const queryToken = parsedUrl.searchParams.get("token");
+  if (queryToken) return queryToken;
+
+  const auth = headers["authorization"];
+  const authStr = Array.isArray(auth) ? auth[0] : auth;
+  if (authStr && /^Bearer\s+/i.test(authStr)) {
+    return authStr.replace(/^Bearer\s+/i, "").trim();
+  }
+
+  const headerToken = headers["x-agend-token"];
+  if (typeof headerToken === "string") return headerToken;
+  if (Array.isArray(headerToken) && headerToken.length > 0) return headerToken[0];
+
+  return null;
+}
+
 export function resolveReplyThreadId(
   argsThreadId: unknown,
   instanceConfig?: InstanceConfig,
@@ -2151,12 +2180,11 @@ Design Proposed → Design Approved → Implementation → Submit for Review →
       if (req.method === "GET" && req.url === "/health") {
         // fallthrough to existing handler below
       } else {
-        // All other endpoints require a valid token (query ?token= or X-Agend-Token header).
+        // All other endpoints require a valid token. Accepts ?token= query,
+        // Authorization: Bearer <token>, or legacy X-Agend-Token header.
         // /ui/* will also re-check in web-api.ts, which is harmless.
         const parsedUrl = new URL(req.url ?? "/", `http://localhost:${port}`);
-        const headerToken = req.headers["x-agend-token"];
-        const providedToken = parsedUrl.searchParams.get("token")
-          ?? (typeof headerToken === "string" ? headerToken : null);
+        const providedToken = extractWebToken(parsedUrl, req.headers);
         if (!this.webToken || providedToken !== this.webToken) {
           res.writeHead(401);
           res.end(JSON.stringify({ error: "Unauthorized" }));
@@ -2224,7 +2252,8 @@ Design Proposed → Design Approved → Implementation → Submit for Review →
             currentTask,
           };
         });
-        res.setHeader("Access-Control-Allow-Origin", "*");
+        // Same-origin only — token-bearing requests come from the dashboard
+        // served by this same daemon, so no CORS allowance is needed.
         res.writeHead(200);
         res.end(JSON.stringify({
           ...sysInfo,
@@ -2248,7 +2277,7 @@ Design Proposed → Design Approved → Implementation → Submit for Review →
         }
 
         const rows = this.eventLog?.listActivity({ since: sinceIso, limit: parseInt(limitParam, 10) }) ?? [];
-        res.setHeader("Access-Control-Allow-Origin", "*");
+        // Same-origin only — see /api/fleet rationale.
         res.writeHead(200);
         res.end(JSON.stringify(rows));
         return;

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -16,6 +16,11 @@ function validateTimezone(tz: string): void {
 }
 
 export class Scheduler {
+  /** Cap how far back we look for missed fires on init. Avoids dumping
+   * dozens of "morning standup" pings on the user after a long outage,
+   * while still recovering from short crashes/restarts. */
+  private static readonly CATCHUP_WINDOW_MS = 24 * 60 * 60 * 1000;
+
   readonly db: SchedulerDb;
   private jobs: Map<string, Cron> = new Map();
   private onTrigger: (schedule: Schedule) => void | Promise<void>;
@@ -39,7 +44,41 @@ export class Scheduler {
 
   init(): void {
     this.db.pruneOldRuns();
+    this.runCatchUp();
     this.registerAllJobs();
+  }
+
+  /**
+   * On startup, fire any schedule whose most recent expected run was missed
+   * within the catch-up window. Only one catch-up fire per schedule — we
+   * don't replay every missed minute of `* * * * *`. Schedules that haven't
+   * been triggered yet use `created_at` as the reference point so a new
+   * schedule registered while the daemon was down still gets caught up.
+   */
+  private runCatchUp(): void {
+    const now = Date.now();
+    const cutoff = now - Scheduler.CATCHUP_WINDOW_MS;
+    for (const schedule of this.db.list()) {
+      if (!schedule.enabled) continue;
+
+      const refIso = schedule.last_triggered_at ?? schedule.created_at;
+      const refMs = Date.parse(refIso);
+      if (Number.isNaN(refMs)) continue;
+
+      try {
+        const cron = new Cron(schedule.cron, { timezone: schedule.timezone });
+        const next = cron.nextRun(new Date(refMs));
+        if (!next) continue;
+        const nextMs = next.getTime();
+        if (nextMs > now) continue;       // not yet due
+        if (nextMs < cutoff) continue;    // too old, don't spam
+        if (this.executing.has(schedule.id)) continue;
+        this.runWithLock(schedule);
+      } catch {
+        // Bad cron expression or croner edge case — skip rather than crash init
+        continue;
+      }
+    }
   }
 
   reload(): void {

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -1,6 +1,7 @@
 import { Cron } from "croner";
 import { SchedulerDb } from "./db.js";
 import type { Schedule, CreateScheduleParams, UpdateScheduleParams, SchedulerConfig, ScheduleRun } from "./types.js";
+import type { Logger } from "../logger.js";
 
 /**
  * Reject unknown timezones. Uses `Intl.DateTimeFormat`, which throws RangeError
@@ -35,6 +36,7 @@ export class Scheduler {
     onTrigger: (schedule: Schedule) => void | Promise<void>,
     config: SchedulerConfig,
     isValidInstance: (name: string) => boolean,
+    private logger?: Logger,
   ) {
     this.db = new SchedulerDb(dbPath);
     this.onTrigger = onTrigger;
@@ -73,6 +75,15 @@ export class Scheduler {
         if (nextMs > now) continue;       // not yet due
         if (nextMs < cutoff) continue;    // too old, don't spam
         if (this.executing.has(schedule.id)) continue;
+        // Distinguish catch-up fires from regular cron fires in the log so
+        // a "why did I just get a 9am standup at 3pm?" question is answerable.
+        this.logger?.info({
+          id: schedule.id,
+          label: schedule.label,
+          cron: schedule.cron,
+          missedAt: new Date(nextMs).toISOString(),
+          delayMs: now - nextMs,
+        }, "Scheduler catch-up: firing missed run");
         this.runWithLock(schedule);
       } catch {
         // Bad cron expression or croner edge case — skip rather than crash init

--- a/src/tmux-control.ts
+++ b/src/tmux-control.ts
@@ -33,6 +33,7 @@ export class TmuxControlClient extends EventEmitter {
   private rl: Interface | null = null;
   private lastOutputAt = new Map<string, number>(); // paneId → timestamp
   private paneToWindow = new Map<string, string>();  // paneId → windowId
+  private registeredWindows = new Set<string>();    // windowIds we should re-resolve on reconnect
   private stopped = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -65,6 +66,24 @@ export class TmuxControlClient extends EventEmitter {
    * Call this after createWindow().
    */
   async registerWindow(windowId: string): Promise<void> {
+    this.registeredWindows.add(windowId);
+    await this.resolvePane(windowId);
+  }
+
+  /** Unregister a window (call on killWindow) */
+  unregisterWindow(windowId: string): void {
+    this.registeredWindows.delete(windowId);
+    for (const [pane, win] of this.paneToWindow) {
+      if (win === windowId) {
+        this.paneToWindow.delete(pane);
+        this.lastOutputAt.delete(pane);
+        break;
+      }
+    }
+  }
+
+  /** Resolve a window's current pane id and cache the mapping. */
+  private async resolvePane(windowId: string): Promise<void> {
     try {
       const paneId = await execTmux([
         "list-panes", "-t", `${this.sessionName}:${windowId}`,
@@ -76,17 +95,6 @@ export class TmuxControlClient extends EventEmitter {
       }
     } catch {
       this.logger?.debug({ windowId }, "Failed to resolve pane ID for window");
-    }
-  }
-
-  /** Unregister a window (call on killWindow) */
-  unregisterWindow(windowId: string): void {
-    for (const [pane, win] of this.paneToWindow) {
-      if (win === windowId) {
-        this.paneToWindow.delete(pane);
-        this.lastOutputAt.delete(pane);
-        break;
-      }
     }
   }
 
@@ -161,6 +169,13 @@ export class TmuxControlClient extends EventEmitter {
   private connect(): void {
     if (this.stopped) return;
 
+    // Pane IDs are tmux-server-scoped: a server restart (or a long-enough
+    // disconnect that windows churned) can leave our cached paneId →
+    // windowId mapping pointing at a stale or recycled pane. Drop the
+    // cache and re-resolve every registered window from the new server.
+    this.paneToWindow.clear();
+    this.lastOutputAt.clear();
+
     this.proc = spawn("tmux", tmuxArgs(["-C", "attach", "-t", this.sessionName, "-r"]), {
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -179,6 +194,12 @@ export class TmuxControlClient extends EventEmitter {
     this.proc.on("error", (err) => {
       this.logger?.warn({ err: (err as Error).message }, "Control mode spawn error");
     });
+
+    // Re-resolve panes for any windows that were registered before this
+    // (re)connect. Safe even on first connect: registeredWindows is empty.
+    for (const windowId of this.registeredWindows) {
+      void this.resolvePane(windowId);
+    }
 
     this.logger?.debug("tmux control mode connected");
   }

--- a/src/transcript-monitor.ts
+++ b/src/transcript-monitor.ts
@@ -10,6 +10,7 @@ export class TranscriptMonitor extends EventEmitter {
   private transcriptPath: string | null = null;
   private pollTimer: ReturnType<typeof setInterval> | null = null;
   private offsetFile: string;
+  private polling = false; // reentry guard for pollIncrement
 
   constructor(private instanceDir: string, private logger: Logger) {
     super();
@@ -54,6 +55,19 @@ export class TranscriptMonitor extends EventEmitter {
   }
 
   async pollIncrement(): Promise<void> {
+    // Reentry guard: setInterval keeps firing even when the previous poll is
+    // still awaiting stat/read. Two concurrent runs would race on byteOffset
+    // (both could read the same byte range and emit duplicate entries).
+    if (this.polling) return;
+    this.polling = true;
+    try {
+      await this._doPoll();
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  private async _doPoll(): Promise<void> {
     if (!this.transcriptPath) {
       this.transcriptPath = await this.resolveTranscriptPath();
       if (!this.transcriptPath) return;

--- a/tests/extract-web-token.test.ts
+++ b/tests/extract-web-token.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { extractWebToken } from "../src/fleet-manager.js";
+
+function url(qs = ""): URL {
+  return new URL(`http://localhost:8080/api/fleet${qs}`);
+}
+
+describe("extractWebToken", () => {
+  it("returns null when no token is provided", () => {
+    expect(extractWebToken(url(), {})).toBeNull();
+  });
+
+  it("reads ?token= query parameter", () => {
+    expect(extractWebToken(url("?token=abc123"), {})).toBe("abc123");
+  });
+
+  it("reads Authorization: Bearer header", () => {
+    expect(extractWebToken(url(), { authorization: "Bearer abc123" })).toBe("abc123");
+  });
+
+  it("Bearer header is case-insensitive", () => {
+    expect(extractWebToken(url(), { authorization: "bearer abc123" })).toBe("abc123");
+    expect(extractWebToken(url(), { authorization: "BEARER abc123" })).toBe("abc123");
+  });
+
+  it("ignores Authorization without Bearer prefix", () => {
+    expect(extractWebToken(url(), { authorization: "Basic abc123" })).toBeNull();
+  });
+
+  it("falls back to legacy X-Agend-Token header", () => {
+    expect(extractWebToken(url(), { "x-agend-token": "legacy-token" })).toBe("legacy-token");
+  });
+
+  it("query string wins over headers (single source of truth for browsers)", () => {
+    expect(extractWebToken(url("?token=q"), {
+      authorization: "Bearer b",
+      "x-agend-token": "x",
+    })).toBe("q");
+  });
+
+  it("Bearer wins over legacy X-Agend-Token", () => {
+    expect(extractWebToken(url(), {
+      authorization: "Bearer b",
+      "x-agend-token": "x",
+    })).toBe("b");
+  });
+
+  it("handles array-valued headers (Node may give string[])", () => {
+    expect(extractWebToken(url(), { authorization: ["Bearer arr"] })).toBe("arr");
+    expect(extractWebToken(url(), { "x-agend-token": ["arr"] })).toBe("arr");
+  });
+
+  it("trims whitespace inside Bearer value", () => {
+    expect(extractWebToken(url(), { authorization: "Bearer   spaced  " })).toBe("spaced");
+  });
+});

--- a/tests/scheduler-catchup.test.ts
+++ b/tests/scheduler-catchup.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdirSync, rmSync } from "node:fs";
+import Database from "better-sqlite3";
+import { Scheduler } from "../src/scheduler/scheduler.js";
+import { DEFAULT_SCHEDULER_CONFIG, type Schedule } from "../src/scheduler/types.js";
+
+/**
+ * Seed last_triggered_at directly via raw sqlite — Scheduler/SchedulerDb
+ * only update it through recordRun(datetime('now')), so to simulate a
+ * missed-fire scenario we have to backdate the row ourselves.
+ */
+function setLastTriggered(dbPath: string, id: string, iso: string | null): void {
+  const raw = new Database(dbPath);
+  raw.prepare("UPDATE schedules SET last_triggered_at = ? WHERE id = ?").run(iso, id);
+  raw.close();
+}
+
+function setCreatedAt(dbPath: string, id: string, iso: string): void {
+  const raw = new Database(dbPath);
+  raw.prepare("UPDATE schedules SET created_at = ? WHERE id = ?").run(iso, id);
+  raw.close();
+}
+
+function setEnabled(dbPath: string, id: string, enabled: boolean): void {
+  const raw = new Database(dbPath);
+  raw.prepare("UPDATE schedules SET enabled = ? WHERE id = ?").run(enabled ? 1 : 0, id);
+  raw.close();
+}
+
+describe("Scheduler — catch-up on init", () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let fired: Schedule[];
+  let scheduler: Scheduler | null;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `sched-catchup-${Date.now()}-${Math.random()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    dbPath = join(tmpDir, "scheduler.db");
+    fired = [];
+    scheduler = null;
+  });
+
+  afterEach(() => {
+    scheduler?.shutdown();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeScheduler(): Scheduler {
+    return new Scheduler(
+      dbPath,
+      (s) => { fired.push(s); },
+      DEFAULT_SCHEDULER_CONFIG,
+      () => true,
+    );
+  }
+
+  function createSchedule(cron: string): Schedule {
+    const seed = makeScheduler();
+    const s = seed.create({
+      cron,
+      message: "ping",
+      source: "test",
+      target: "general",
+      reply_chat_id: "chat-1",
+      reply_thread_id: null,
+    });
+    seed.shutdown();
+    return s;
+  }
+
+  it("fires once for a schedule whose expected run was missed within the window", () => {
+    const s = createSchedule("* * * * *"); // every minute
+    // Last fire was 5 minutes ago → next expected ~4 minutes ago → missed
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    setLastTriggered(dbPath, s.id, fiveMinAgo);
+
+    scheduler = makeScheduler();
+    scheduler.init();
+
+    expect(fired).toHaveLength(1);
+    expect(fired[0].id).toBe(s.id);
+  });
+
+  it("does NOT fire if the missed run is older than the 24h catch-up window", () => {
+    const s = createSchedule("0 9 * * *"); // 9am daily
+    // Last fire was 3 days ago → next expected 2 days ago → way past 24h
+    const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    setLastTriggered(dbPath, s.id, threeDaysAgo);
+
+    scheduler = makeScheduler();
+    scheduler.init();
+
+    expect(fired).toHaveLength(0);
+  });
+
+  it("does NOT fire if the next expected run is still in the future", () => {
+    const s = createSchedule("0 9 * * *"); // 9am daily
+    // Last fire was just now → next expected tomorrow 9am → not due
+    setLastTriggered(dbPath, s.id, new Date().toISOString());
+
+    scheduler = makeScheduler();
+    scheduler.init();
+
+    expect(fired).toHaveLength(0);
+  });
+
+  it("skips disabled schedules", () => {
+    const s = createSchedule("* * * * *");
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    setLastTriggered(dbPath, s.id, fiveMinAgo);
+    setEnabled(dbPath, s.id, false);
+
+    scheduler = makeScheduler();
+    scheduler.init();
+
+    expect(fired).toHaveLength(0);
+  });
+
+  it("uses created_at when last_triggered_at is null", () => {
+    const s = createSchedule("* * * * *");
+    // Never triggered; backdate creation by 5 minutes
+    setLastTriggered(dbPath, s.id, null);
+    setCreatedAt(dbPath, s.id, new Date(Date.now() - 5 * 60 * 1000).toISOString());
+
+    scheduler = makeScheduler();
+    scheduler.init();
+
+    expect(fired).toHaveLength(1);
+    expect(fired[0].id).toBe(s.id);
+  });
+
+  it("fires at most once per schedule, even when many minutes were missed", () => {
+    const s = createSchedule("* * * * *"); // every minute
+    // Last fire was 60 minutes ago → 59 minute fires were missed
+    const hourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    setLastTriggered(dbPath, s.id, hourAgo);
+
+    scheduler = makeScheduler();
+    scheduler.init();
+
+    expect(fired).toHaveLength(1);
+  });
+});

--- a/tests/scheduler-catchup.test.ts
+++ b/tests/scheduler-catchup.test.ts
@@ -5,6 +5,7 @@ import { mkdirSync, rmSync } from "node:fs";
 import Database from "better-sqlite3";
 import { Scheduler } from "../src/scheduler/scheduler.js";
 import { DEFAULT_SCHEDULER_CONFIG, type Schedule } from "../src/scheduler/types.js";
+import type { Logger } from "../src/logger.js";
 
 /**
  * Seed last_triggered_at directly via raw sqlite — Scheduler/SchedulerDb
@@ -34,12 +35,14 @@ describe("Scheduler — catch-up on init", () => {
   let dbPath: string;
   let fired: Schedule[];
   let scheduler: Scheduler | null;
+  let infoLogs: Array<{ obj: Record<string, unknown>; msg: string }>;
 
   beforeEach(() => {
     tmpDir = join(tmpdir(), `sched-catchup-${Date.now()}-${Math.random()}`);
     mkdirSync(tmpDir, { recursive: true });
     dbPath = join(tmpDir, "scheduler.db");
     fired = [];
+    infoLogs = [];
     scheduler = null;
   });
 
@@ -49,11 +52,18 @@ describe("Scheduler — catch-up on init", () => {
   });
 
   function makeScheduler(): Scheduler {
+    const noop = () => {};
+    const logger = {
+      info: (obj: Record<string, unknown>, msg: string) => infoLogs.push({ obj, msg }),
+      warn: noop, error: noop, debug: noop, trace: noop, fatal: noop,
+      child: () => logger,
+    } as unknown as Logger;
     return new Scheduler(
       dbPath,
       (s) => { fired.push(s); },
       DEFAULT_SCHEDULER_CONFIG,
       () => true,
+      logger,
     );
   }
 
@@ -142,5 +152,21 @@ describe("Scheduler — catch-up on init", () => {
     scheduler.init();
 
     expect(fired).toHaveLength(1);
+  });
+
+  it("logs catch-up fires distinctly so they can be told apart from regular cron fires", () => {
+    const s = createSchedule("* * * * *");
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    setLastTriggered(dbPath, s.id, fiveMinAgo);
+
+    scheduler = makeScheduler();
+    scheduler.init();
+
+    const catchUpLog = infoLogs.find((l) => l.msg.includes("catch-up"));
+    expect(catchUpLog).toBeDefined();
+    expect(catchUpLog!.obj.id).toBe(s.id);
+    expect(catchUpLog!.obj.cron).toBe("* * * * *");
+    expect(typeof catchUpLog!.obj.missedAt).toBe("string");
+    expect(typeof catchUpLog!.obj.delayMs).toBe("number");
   });
 });

--- a/tests/telegram-api-root.test.ts
+++ b/tests/telegram-api-root.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { validateTelegramApiRoot } from "../src/channel/adapters/telegram.js";
+
+describe("validateTelegramApiRoot", () => {
+  it("accepts the official Telegram API root", () => {
+    expect(() => validateTelegramApiRoot("https://api.telegram.org")).not.toThrow();
+  });
+
+  it("accepts loopback hosts (E2E mock servers)", () => {
+    expect(() => validateTelegramApiRoot("http://localhost:8081")).not.toThrow();
+    expect(() => validateTelegramApiRoot("http://127.0.0.1:8081")).not.toThrow();
+    expect(() => validateTelegramApiRoot("http://[::1]:8081")).not.toThrow();
+  });
+
+  it("rejects arbitrary external hosts (token-exfil risk)", () => {
+    expect(() => validateTelegramApiRoot("https://evil.example.com")).toThrow(/allowlist/i);
+    expect(() => validateTelegramApiRoot("https://api.telegram.org.evil.com")).toThrow(/allowlist/i);
+  });
+
+  it("rejects api.telegram.org over plain http (forces https)", () => {
+    expect(() => validateTelegramApiRoot("http://api.telegram.org")).toThrow(/https/i);
+  });
+
+  it("rejects non-http(s) schemes", () => {
+    expect(() => validateTelegramApiRoot("file:///etc/passwd")).toThrow(/http/i);
+    expect(() => validateTelegramApiRoot("ftp://api.telegram.org")).toThrow(/http/i);
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(() => validateTelegramApiRoot("not a url")).toThrow(/Invalid/i);
+    expect(() => validateTelegramApiRoot("")).toThrow(/Invalid/i);
+  });
+
+  it("hostname matching is case-insensitive", () => {
+    expect(() => validateTelegramApiRoot("https://API.TELEGRAM.ORG")).not.toThrow();
+  });
+});

--- a/tests/tmux-control.test.ts
+++ b/tests/tmux-control.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { EventEmitter } from "node:events";
+
+// ── Mock node:child_process & node:readline so we never spawn real tmux ──
+const spawnMock = vi.fn();
+const execFileMock = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+  execFile: (...args: unknown[]) => execFileMock(...args),
+}));
+
+vi.mock("node:readline", () => ({
+  createInterface: vi.fn(() => ({ on: vi.fn(), close: vi.fn() })),
+}));
+
+import { TmuxControlClient } from "../src/tmux-control.js";
+
+interface FakeProc extends EventEmitter {
+  stdout: EventEmitter;
+  stdin: { write: ReturnType<typeof vi.fn> };
+  killed: boolean;
+  kill: () => void;
+}
+
+function makeFakeProc(): FakeProc {
+  const proc = new EventEmitter() as FakeProc;
+  proc.stdout = new EventEmitter();
+  proc.stdin = { write: vi.fn() };
+  proc.killed = false;
+  proc.kill = () => { proc.killed = true; };
+  return proc;
+}
+
+interface ClientInternals {
+  paneToWindow: Map<string, string>;
+  lastOutputAt: Map<string, number>;
+  registeredWindows: Set<string>;
+  connect: () => void;
+}
+
+describe("TmuxControlClient reconnect", () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+    execFileMock.mockReset();
+    spawnMock.mockReturnValue(makeFakeProc());
+    // Default: execFile returns empty stdout so resolvePane is a harmless no-op
+    execFileMock.mockImplementation((_cmd, _args, cb: (e: Error | null, s: string) => void) => cb(null, ""));
+  });
+
+  it("registerWindow tracks the windowId for future reconnects", async () => {
+    const client = new TmuxControlClient("s", 100);
+    const internal = client as unknown as ClientInternals;
+
+    execFileMock.mockImplementationOnce((_c, _a, cb) => cb(null, "%1"));
+    await client.registerWindow("@10");
+
+    expect(internal.registeredWindows.has("@10")).toBe(true);
+    expect(internal.paneToWindow.get("%1")).toBe("@10");
+  });
+
+  it("unregisterWindow removes from registeredWindows AND pane caches", () => {
+    const client = new TmuxControlClient("s", 100);
+    const internal = client as unknown as ClientInternals;
+    internal.registeredWindows.add("@5");
+    internal.paneToWindow.set("%1", "@5");
+    internal.lastOutputAt.set("%1", Date.now());
+
+    client.unregisterWindow("@5");
+
+    expect(internal.registeredWindows.has("@5")).toBe(false);
+    expect(internal.paneToWindow.has("%1")).toBe(false);
+    expect(internal.lastOutputAt.has("%1")).toBe(false);
+  });
+
+  it("clears stale paneToWindow / lastOutputAt on reconnect", () => {
+    const client = new TmuxControlClient("s", 100);
+    const internal = client as unknown as ClientInternals;
+    // Simulate state from a prior connection
+    internal.paneToWindow.set("%1", "@5");
+    internal.lastOutputAt.set("%1", Date.now());
+    internal.registeredWindows.add("@5");
+
+    internal.connect();
+
+    expect(internal.paneToWindow.size).toBe(0);
+    expect(internal.lastOutputAt.size).toBe(0);
+    // Registered windows are preserved so resolvePane can refresh them
+    expect(internal.registeredWindows.has("@5")).toBe(true);
+  });
+
+  it("re-resolves all registered windows after reconnect", async () => {
+    const client = new TmuxControlClient("s", 100);
+    const internal = client as unknown as ClientInternals;
+    internal.registeredWindows.add("@5");
+    internal.registeredWindows.add("@7");
+
+    const seen: string[] = [];
+    execFileMock.mockImplementation((_cmd, args: string[], cb: (e: Error | null, s: string) => void) => {
+      seen.push(args.join(" "));
+      cb(null, "%99");
+    });
+
+    internal.connect();
+    // Allow the fired-and-forget resolvePane promises to settle
+    await new Promise(r => setImmediate(r));
+
+    expect(seen.some(s => s.includes("@5"))).toBe(true);
+    expect(seen.some(s => s.includes("@7"))).toBe(true);
+  });
+});

--- a/tests/transcript-monitor.test.ts
+++ b/tests/transcript-monitor.test.ts
@@ -81,4 +81,19 @@ describe("TranscriptMonitor", () => {
     await monitor.pollIncrement(); // no new data
     expect(texts).toHaveLength(1);
   });
+
+  it("skips concurrent pollIncrement calls (reentry guard)", async () => {
+    const jsonlPath = join(tmpDir, "transcript.jsonl");
+    const entry = { message: { role: "assistant", content: [{ type: "text", text: "once" }] } };
+    writeFileSync(jsonlPath, JSON.stringify(entry) + "\n");
+
+    monitor.setTranscriptPath(jsonlPath);
+    const texts: string[] = [];
+    monitor.on("assistant_text", (text) => texts.push(text));
+
+    // Fire two polls simultaneously; second should bail before reading
+    // any bytes, so the entry is emitted exactly once.
+    await Promise.all([monitor.pollIncrement(), monitor.pollIncrement()]);
+    expect(texts).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Summary

Phase 2/3 修復第二輪，5 個獨立 commit、可個別 cherry-pick：

- **P2.1** `fix(tmux): clear stale pane cache on control-mode reconnect` — 重連 tmux 後清掉舊的 paneId→windowId 對照，避免拿到 recycled pane id。
- **P2.4** `fix(transcript): add reentry guard to pollIncrement` — `setInterval` 仍在 fire 時若前一次 poll 還在 await，兩次同時讀同段 byte range 會 emit 重複事件；加 boolean 守衛。
- **P2.3** `fix(scheduler): catch up missed runs within 24h on init` — daemon 重啟期間錯過的 cron fire 會永遠跳過；改成 init 時 walk 一次，最多每個 schedule 補一次（24h 視窗，避免長期離線後一次性大量觸發）。
- **P3.5** `fix(web): drop wildcard CORS, accept Authorization Bearer` — `/api/fleet`、`/api/activity` 之前加 `Access-Control-Allow-Origin: *`；改回 same-origin。同時新增 `Authorization: Bearer` 支援，與舊的 `?token=` / `X-Agend-Token` 並存。
- **P3.3** `fix(telegram): allowlist apiRoot hosts to prevent token exfil` — Telegram bot API 把 token 放在 URL path，誤設 / 被竄改的 `telegram_api_root` 會洩漏 token；只允許 `api.telegram.org` (https) 與 loopback。

## Test plan

- [x] `npx tsc --noEmit` 綠
- [x] `npx vitest run` 433/433 通過（53 個檔案）
- [x] 每個修復都有對應 unit test（合計 +27 個 test）
- [ ] 待 reviewer 抽查 commit 順序是否易讀、commit 訊息與 fix-plan.md 對得上

🤖 Generated with [Claude Code](https://claude.com/claude-code)