### PR TITLE
chore: release 1.23.0 (Phase 1-4 close)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,50 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.23.0] - 2026-04-20
+
+Phase 1–4 of the security/reliability fix plan (`docs/fix-plan.md`) closes here. 36 individual fixes/refactors across 7 PRs (#33, #38, #39, #40, #41, #42, #43, #44).
+
+### Security
+- **Phase 1 boundaries** (PR #33) — per-instance `/agent` token, zod validation on all `/ui/*` mutations, template var sanitization, tar entry validation, symlink resolution for `project_roots`, branch/logPath argument injection hardening, `web.token` 0o600.
+- **Telegram apiRoot allowlist** (P3.3, `9a7b16b`) — prevents bot-token exfil via attacker-controlled `apiRoot`.
+- **Webhook HMAC-SHA256 signing** (P3.1, `e65b97c`) — outbound webhooks now signed; receivers can verify origin.
+- **STT requires explicit opt-in** (P3.4, `1fc513e`) — voice transcription no longer activates from env var alone; needs `stt.enabled: true` in `fleet.yaml`.
+- **`/update` hardened** (P3.6, `740c202`, `d38a583`) — empty `allowed_users` rejects `/update` entirely; two-step token confirm (8 hex, 60s TTL); version pin during install; auto-rollback on health check fail; supersede notifications.
+- **`access-path` rejects path traversal in instance names** (P4.3, `d5d41b7`) — whitelist `^[A-Za-z0-9._-]+$`, rejects `..` / `/` / `\` / NUL.
+- **`.env` file mode 0o600** (P4.4, `49a4328`) — wizard writes credential files with restrictive permissions + chmod fallback.
+- **CORS tightened, Bearer auth supported** (P3.5, `b180232`) — wildcard CORS removed; web API accepts `Authorization: Bearer <token>` header.
+- **`paths.ts` md5 → sha256** (P4.5, `1f91c3c`) — eliminates FIPS / scanner alerts. Custom `AGEND_HOME` users will see tmux session/socket suffix change once on upgrade.
+
+### Fixed
+- **Telegram 409 polling cap** (P3.2, `c67f776`) — caps retries to 30 to prevent infinite poll loops.
+- **Topic archiver persistence** (P2.6, `f134a66`, `42d5d1f`) — archived topic state now persists across restarts via atomic write of `<dataDir>/archived-topics.json`.
+- **IPC single-line buffer cap 10MB → 1MB** (P3.7, `d446384`) — overflow rejected with structured error instead of OOM.
+- **Tmux pane cache invalidation on control-mode reconnect** (P2.1, `e967bbb`).
+- **TranscriptMonitor reentry guard** (P2.4, `65be144`) — prevents overlapping `pollIncrement` runs.
+- **Scheduler catch-up for missed runs within 24h** (P2.3, `01e1e32`, `24d6f8a`).
+- **Cost-guard daily-cap reset on session rotation** (P2.2, `875a0b2`) — `warnEmitted`/`limitEmitted` flags now reset properly so post-rotation sessions don't silently exceed daily cap.
+- **SSE dead client eviction + socket error handling** (P2.5, `ae2a810`) — `broadcastSseEvent` no longer breaks the loop on a dead client write; `req.on("error")` now cleans up client set on ECONNRESET.
+- **Drop redundant sleep+reconnect after instance start** (P2.7, `872547b`) — `startInstance` await chain already guarantees IPC ready; secondary `connectIpcToInstance` was pure dead code.
+- **Cost-guard DST handling** (P2.8, `3c9ff9f`) — `msUntilMidnight` now uses `Intl.DateTimeFormat` + binary search instead of `setHours(24,0,0,0)`, so DST spring/fall transitions don't shift the daily reset by ±1h.
+- **MessageQueue flood-control backoff reset** (P3.8, `3474c04`) — backoff now actually resets after status_update drop instead of staying at ~30s.
+
+### Changed
+- **`fleet-manager.ts` decomposed** (P4.1, PR #43) — 2842 → 1658 lines (-1184). Four new modules:
+  - `fleet-dashboard-html.ts` (442 lines) — dashboard HTML constant
+  - `fleet-instructions.ts` (168 lines) — `GENERAL_INSTRUCTIONS` + `ensureGeneralInstructions`
+  - `fleet-rpc-handlers.ts` (387 lines) — IPC + HTTP CRUD dispatch
+  - `fleet-health-server.ts` (326 lines) — `startHealthServer` + `getUiStatus` + `extractWebToken`
+
+  All modules use a Context-injection pattern: each declares a narrow `XxxContext` interface, FleetManager `implements` it, and exported functions take `this` as their first arg.
+- **`daemon.handleToolCall` factored** (P4.2, `e6a9596`) — extracted `dispatchFleetRpc(fleetReqId, broadcast, timeoutMs, timeoutMessage, respond)` helper. `handleToolCall` 182 → ~120 lines, daemon.ts -51 lines net.
+- **`validateTimezone` unified** (P4.4, `49a4328`) — `scheduler/scheduler.ts` no longer duplicates the validator; imports the canonical version from `config.ts`.
+
+### Docs
+- **`docs/fix-plan.md` Phase 1–4 closed** — all P-items either ✅ or moved to **Deferred / Future Work** (logger rotation, cost-guard tiebreaker — both feature-class, not fix-class).
+- **`docs/p4.1-split-plan.md` archived** — record of the four-module decomposition strategy.
+- **`docs/issue-evaluations.md` added** — analysis of open issues #24 (usage-limit notify) and #8 (default topic preset) with effort/tradeoff breakdowns for future planning.
+
 ## [1.22.1] - 2026-04-19
 
 ### Fixed

--- a/docs/CHANGELOG.zh-TW.md
+++ b/docs/CHANGELOG.zh-TW.md
@@ -6,6 +6,50 @@
 
 ## [未發佈] (Unreleased)
 
+## [1.23.0] - 2026-04-20
+
+收束 `docs/fix-plan.md` Phase 1–4 安全/可靠性修復計畫。共 36 項修復／重構，分散於 7 個 PR（#33, #38, #39, #40, #41, #42, #43, #44）。
+
+### 安全 (Security)
+- **Phase 1 邊界硬化** (PR #33) — 每 instance 獨立 `/agent` token、`/ui/*` 全部 mutation 走 zod 驗證、template 變數消毒、tar entry 驗證、`project_roots` symlink resolve、branch / logPath 防 argument injection、`web.token` 0o600。
+- **Telegram apiRoot 白名單** (P3.3, `9a7b16b`) — 防止透過攻擊者控制的 `apiRoot` 外洩 bot token。
+- **Webhook HMAC-SHA256 簽章** (P3.1, `e65b97c`) — outbound webhook 簽章；接收端可驗證來源。
+- **STT 必須顯式 opt-in** (P3.4, `1fc513e`) — 語音轉文字不再因有 env 就啟用，需 `fleet.yaml` `stt.enabled: true`。
+- **`/update` 安全化** (P3.6, `740c202`, `d38a583`) — 空 `allowed_users` 整個拒絕 `/update`；兩段 token 確認（8 hex、60s TTL）；安裝時版本鎖；健康探針失敗自動回滾；supersede 通知。
+- **`access-path` 拒絕 instance 名 path traversal** (P4.3, `d5d41b7`) — 白名單 `^[A-Za-z0-9._-]+$`，拒 `..` / `/` / `\` / NUL。
+- **`.env` 0o600** (P4.4, `49a4328`) — wizard 寫憑證檔加上嚴格權限 + chmod 兜底。
+- **CORS 收緊、支援 Bearer auth** (P3.5, `b180232`) — 拿掉 wildcard CORS；web API 接受 `Authorization: Bearer <token>`。
+- **`paths.ts` md5 → sha256** (P4.5, `1f91c3c`) — 消除 FIPS／掃描器告警。custom `AGEND_HOME` 用戶升級後 tmux session/socket 後綴會變一次。
+
+### 修正 (Fixed)
+- **Telegram 409 polling 上限** (P3.2, `c67f776`) — retry 上限 30 次，避免無窮 polling。
+- **Topic archiver 持久化** (P2.6, `f134a66`, `42d5d1f`) — archived topic 跨重啟保留，atomic write 至 `<dataDir>/archived-topics.json`。
+- **IPC 單行上限 10MB → 1MB** (P3.7, `d446384`) — overflow 結構化拒絕,避免 OOM。
+- **Tmux pane cache 在 control-mode 重連時清除** (P2.1, `e967bbb`)。
+- **TranscriptMonitor 重入鎖** (P2.4, `65be144`) — 防止重疊的 `pollIncrement`。
+- **Scheduler 啟動時 catch-up 24h 內漏跑** (P2.3, `01e1e32`, `24d6f8a`)。
+- **Cost-guard session rotation 重置 emitted flags** (P2.2, `875a0b2`) — `warnEmitted` / `limitEmitted` 正確重置，rotation 後新 session 不會無聲衝過 daily cap。
+- **SSE dead client 驅逐 + socket error 處理** (P2.5, `ae2a810`) — `broadcastSseEvent` 對單一 dead client 寫入失敗不再 break 整個 loop；`req.on("error")` 在 ECONNRESET 清理 client set。
+- **拿掉 instance 啟動後多餘的 sleep+reconnect** (P2.7, `872547b`) — `startInstance` await 鏈已保證 IPC 就緒。
+- **Cost-guard DST 處理** (P2.8, `3c9ff9f`) — `msUntilMidnight` 改用 `Intl.DateTimeFormat` + 二分搜尋，DST 春令／秋令日不再偏 ±1h。
+- **MessageQueue flood-control backoff 重置** (P3.8, `3474c04`) — drop 後 backoff 真正重置，不會卡在 ~30s。
+
+### 變更 (Changed)
+- **`fleet-manager.ts` 拆檔** (P4.1, PR #43) — 2842 → 1658 行（-1184）。新增四個模組：
+  - `fleet-dashboard-html.ts`（442 行）— dashboard HTML 常數
+  - `fleet-instructions.ts`（168 行）— `GENERAL_INSTRUCTIONS` + `ensureGeneralInstructions`
+  - `fleet-rpc-handlers.ts`（387 行）— IPC + HTTP CRUD dispatch
+  - `fleet-health-server.ts`（326 行）— `startHealthServer` + `getUiStatus` + `extractWebToken`
+
+  皆採 Context-injection：模組宣告 narrow `XxxContext` interface、FleetManager `implements`、外部以 `this` 呼叫純函數。
+- **`daemon.handleToolCall` 抽出 helper** (P4.2, `e6a9596`) — 抽出 `dispatchFleetRpc(...)`。`handleToolCall` 182 → ~120 行，daemon.ts 淨 -51 行。
+- **`validateTimezone` 單一化** (P4.4, `49a4328`) — `scheduler/scheduler.ts` 移除本地副本，import `config.ts` 的版本。
+
+### 文件 (Docs)
+- **`docs/fix-plan.md` Phase 1–4 結案** — 所有 P 項目皆 ✅ 或移至 **Deferred / Future Work**（logger rotation、cost-guard tiebreaker 兩項屬 feature 不屬 fix）。
+- **`docs/p4.1-split-plan.md` 歸檔** — 四模組拆檔策略紀錄。
+- **`docs/issue-evaluations.md` 新增** — 對 open issue #24（usage-limit notify）、#8（default topic preset）做效益／tradeoff 分析，供未來規劃用。
+
 ## [1.22.1] - 2026-04-19
 
 ### 修正

--- a/docs/issue-evaluations.md
+++ b/docs/issue-evaluations.md
@@ -1,0 +1,88 @@
+# Issue Evaluations
+
+存放對 GitHub open issues 的效益／tradeoff 分析。日後若決定動工，可直接從這裡延伸到 feature-roadmap.md 或 fix-plan。
+
+---
+
+## #24 — Notify sender when recipient instance has hit usage limit
+
+**狀態**：未排入計畫（2026-04-20 評估）
+**類型**：feature（不屬安全/可靠性 fix）
+
+### 痛點（原 issue 摘要）
+
+- Recipient instance（如 codex backend）在任務途中 hit usage limit 後仍會回覆，但回覆是不完整或捏造的。
+- Sender（general）無從得知，要嘛無限等待、要嘛根據假回報行動。
+- 當前 workaround：sender 對所有 critical operation 手動驗證。
+
+### 效益
+
+- **正確性 ↑↑**：消除 silent failure；sender 收到結構化 error 後可改路由或停手。
+- **多 instance 編排可行性 ↑**：fleet 越大、limit-trip 機率越高；無回饋拉低 multi-backend 組合的可用性上限。
+- **實作成本低**：基礎設施齊備：
+  - `cost-guard.isLimited(instance)` 已存在（`src/cost-guard.ts:147`）
+  - FleetManager 持有 `costGuard`
+  - `OutboundContext` 已能接到 fleet config／lifecycle
+  - 只差在 `sendToInstance` / `delegateTask` dispatch 前加一道 `isLimited` 檢查 + respond error
+  - 粗估 < 50 行 + 2-3 個 unit test
+
+### Tradeoff / 風險
+
+- **Race window**：limit 是事件性檢查；A 已 dispatch 但 recipient 在 1ms 內 trip → 仍可能漏掉。pre-dispatch 處理 90% 場景，剩下需 recipient-side 在 IPC response 標記 `limit_tripped`，但會擴大 scope。
+- **Policy 設計題**：trip 後是 (a) reject 並讓 sender 自行 retry／改路由、(b) queue 待 limit reset、(c) overflow 給其他同 backend instance？issue 提到 (a)/(b)，需先決策。**queue 路線**等於要新增 persistence + retry policy + TTL，容易膨脹。
+- **跨 backend 不一致**：`isLimited` 目前只看 `daily_limit_usd`；codex 有 daily quota 但 claude-code 是 5h window，目前無感知。解了 issue 也只解了 budget-limit、解不了 backend-specific rate-limit。標題的「usage limit」其實混合兩件事。
+- **行為改變**：先前可發出的呼叫現在會回 error；少量行為破壞性，但 sender 的 LLM 對 error response 一般能正確處理。
+
+### 建議 scope（KISS）
+
+- **Phase A**：pre-dispatch 加 `isLimited` 檢查，return 結構化 error（含 `target`, `reason: "daily_limit_reached"`, `reset_at`）。不做 queue。
+- **Phase B**（後續）：recipient-side 在 IPC response 標 `limit_tripped: true`，sender 收到後 surface。
+- Queue 留給 Phase C，多數需求 Phase A 已解掉。
+
+---
+
+## #8 — Default topic package for new users
+
+**狀態**：未排入計畫（2026-04-20 評估）
+**類型**：feature
+
+### 痛點（原 issue 摘要）
+
+- 新用戶第一次用 agend 時，要自行決定開幾個 instance、各自 prompt 怎寫、如何協作。
+- 希望 wizard 提供一組「general + planner + builder + reviewer」之類已驗證可協作的預設組合，用戶之後再透過 `post_decisions` 或編 fleet.yaml 微調。
+
+### 效益
+
+- **第一次體驗 ↑**：直接降低 onboarding 門檻。
+- **Best-practice 內建**：把分工模式變成預設值，避免新手用一個 instance 包山包海。
+- **示範材料**：preset 本身是好的 example，幫助後續編 fleet.yaml 有參考。
+
+### Tradeoff / 風險
+
+- **Maintenance burden**：preset 進 repo 後，每次改 backend／IPC／system prompt schema 都要同步維護；很容易腐爛成 stale 範例。
+- **Opinion lock-in**：選哪一組 preset、planner 用什麼 backend、token 預算多少都是強 opinion；用戶 backend／預算／工作流不同，preset 的「最佳實踐」很可能不適用。
+- **依賴外部 API key**：每個 preset agent 需要對應 backend 已安裝＋有 key；wizard 必須先檢測再篩可用 preset，否則建出來跑不動更糟。
+- **Token 預算**：4 個 instance 同時跑，cost 直接 ×4；對沒注意 budget 的新手會踩雷（剛好跟 #24 互相關聯）。
+- **與 fleet.yaml 直編的衝突**：用戶若用 wizard 建 preset 後又手動編，preset upgrade 怎麼處理？需 versioning 或文件講清楚「preset 只是初始種子，之後不追蹤」。
+- **實作成本中**：不只新增 YAML template，還要 wizard flow 多一個分支、檢測可用 backend、產生 system prompt、解釋角色——比 #24 複雜不少。
+
+### 建議 scope（KISS）
+
+- 不做「精緻可擴充的 template framework」。
+- 提供 1-2 個 hard-coded preset YAML（例：「Solo Coding（general + builder）」、「Planning Team（general + planner + builder + reviewer）」），放 `src/presets/`。
+- Wizard 多一個問題：「想要 (1) preset (2) 自己一個 instance」；choose preset 後自動寫 fleet.yaml，**不維護 upgrade path**——明示「之後請直接編 fleet.yaml」。
+- 完全不做 backend 自動檢測；preset 設定統一用 wizard 已選的 default backend。
+
+---
+
+## 比較與優先序建議
+
+| 維度 | #24 usage-limit notify | #8 default preset |
+|---|---|---|
+| 解決痛點明確度 | 高（issue 描述具體 reproducible） | 中（onboarding 抽象痛點） |
+| 實作成本 | 小（< 50 行 + 測試） | 中（wizard flow + preset 維護） |
+| 行為改變風險 | 低-中（多了 reject 路徑） | 無（純新功能，不動既有 user） |
+| 維護負擔 | 低 | 中-高（preset 易腐） |
+| 影響範圍 | 所有多 instance 用戶 | 只影響首次 setup |
+
+**推薦優先序**：先做 #24 Phase A（高 ROI、低風險、issue 具體），#8 視社群迴響再決定要不要做 minimal 版。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@suzuke/agend",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@suzuke/agend",
-      "version": "1.22.1",
+      "version": "1.23.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suzuke/agend",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "Multi-agent fleet daemon — run any coding CLI (Claude, Gemini, Codex, OpenCode) from Telegram",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump version `1.22.1` → `1.23.0` (minor; large security + reliability batch + refactor)
- CHANGELOG.md / CHANGELOG.zh-TW.md updated with full breakdown of 36 commits across PRs #33, #38, #39, #40, #41, #42, #43, #44
- Added `docs/issue-evaluations.md` documenting effort/tradeoff analysis for open issues #24 (usage-limit notify) and #8 (default topic preset) — for future planning, not action

## Why minor (not patch)
44 commits since 1.22.1 covering:
- 9 security hardenings (incl. Phase 1 boundaries, webhook HMAC, /update auth)
- 11 reliability fixes (cost-guard DST, SSE eviction, IPC cap, scheduler catch-up, etc.)
- Major refactor: `fleet-manager.ts` 2842 → 1658 lines, 4 new modules
- Behavioral changes (e.g., STT now requires explicit opt-in, paths.ts md5→sha256 changes tmux suffix once)

## Test plan
- [x] `npx tsc --noEmit` 綠
- [x] `npx vitest run` 491/491 全綠
- [ ] Merge → tag `v1.23.0` → `npm publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)