### PR TITLE
fix(daemon): stop health check when instance directory is removed externally

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **Health check loop stops when instance directory is removed externally** — previously, `rm -rf ~/.agend/instances/<name>` while the daemon was running caused the health check to respawn-crash every ~30s indefinitely, spamming `ENOENT … rotation-state.json` / `tmux server died` / `Failed to respawn Claude window`. Loop now detects missing `instanceDir` at the start of each tick and pauses itself.
+
 ## [1.23.0] - 2026-04-20
 
 Phase 1–4 of the security/reliability fix plan (`docs/fix-plan.md`) closes here. 36 individual fixes/refactors across 7 PRs (#33, #38, #39, #40, #41, #42, #43, #44).

--- a/docs/CHANGELOG.zh-TW.md
+++ b/docs/CHANGELOG.zh-TW.md
@@ -6,6 +6,9 @@
 
 ## [未發佈] (Unreleased)
 
+### 修復 (Fixed)
+- **Instance 目錄被外部刪除時健康檢查迴圈會停止** — 先前若 daemon 執行中有人 `rm -rf ~/.agend/instances/<name>`，健康檢查每 ~30s 會不斷嘗試 respawn，產生 `ENOENT … rotation-state.json` / `tmux server died` / `Failed to respawn Claude window` 的連鎖錯誤 spam。現在每次 tick 開頭會檢查 `instanceDir` 是否還存在，不存在就暫停該 instance 的健康檢查。
+
 ## [1.23.0] - 2026-04-20
 
 收束 `docs/fix-plan.md` Phase 1–4 安全/可靠性修復計畫。共 36 項修復／重構，分散於 7 個 PR（#33, #38, #39, #40, #41, #42, #43, #44）。

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -327,6 +327,16 @@ export class Daemon extends EventEmitter {
 
     const scheduleNext = () => {
       this.healthCheckTimer = setTimeout(async () => {
+        // Instance directory removed externally (e.g. `rm -rf ~/.agend/instances/<name>`).
+        // Stop the loop permanently — otherwise every tick triggers a respawn, whose
+        // writeRotationSnapshot fails with ENOENT and gets caught as "Failed to respawn",
+        // spamming errors every ~30s forever.
+        if (!existsSync(this.instanceDir)) {
+          this.logger.warn({ instanceDir: this.instanceDir }, "Instance directory missing — stopping health check");
+          this.healthCheckPaused = true;
+          this.healthCheckTimer = null;
+          return;
+        }
         if (!this.tmux || this.spawning || this.healthCheckPaused || Daemon.tmuxServerPaused) {
           scheduleNext();
           return;


### PR DESCRIPTION
## Summary
- `rm -rf ~/.agend/instances/<name>` while daemon runs caused the health check to spam ENOENT + tmux-died + respawn-failed every ~30s forever (observed 5000+ errors in ~20h in `~/.agend/daemon.log`)
- Root cause: each tick saw pane dead → respawn path → `writeRotationSnapshot` → `writeFileSync` ENOENT → caught as "Failed to respawn" → `scheduleNext()` → loop
- Fix: check `existsSync(instanceDir)` at the start of each tick; if missing, pause the loop and clear the timer

## Test plan
- [x] Full unit suite: 508/508 passed (`npx vitest run`)
- [x] Build clean (`npm run build`)
- [ ] Verify in real daemon: run daemon with instance, `rm -rf ~/.agend/instances/<name>`, confirm only a single "Instance directory missing" warn line (no more ENOENT/tmux spam)