### PR TITLE
chore: release 1.23.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.23.1] - 2026-04-21
+
 ### Fixed
-- **Health check loop stops when instance directory is removed externally** — previously, `rm -rf ~/.agend/instances/<name>` while the daemon was running caused the health check to respawn-crash every ~30s indefinitely, spamming `ENOENT … rotation-state.json` / `tmux server died` / `Failed to respawn Claude window`. Loop now detects missing `instanceDir` at the start of each tick and pauses itself.
+- **Health check loop stops when instance directory is removed externally** (PR #46) — previously, `rm -rf ~/.agend/instances/<name>` while the daemon was running caused the health check to respawn-crash every ~30s indefinitely, spamming `ENOENT … rotation-state.json` / `tmux server died` / `Failed to respawn Claude window`. Loop now detects missing `instanceDir` at the start of each tick and pauses itself.
 
 ## [1.23.0] - 2026-04-20
 

--- a/docs/CHANGELOG.zh-TW.md
+++ b/docs/CHANGELOG.zh-TW.md
@@ -6,8 +6,10 @@
 
 ## [未發佈] (Unreleased)
 
+## [1.23.1] - 2026-04-21
+
 ### 修復 (Fixed)
-- **Instance 目錄被外部刪除時健康檢查迴圈會停止** — 先前若 daemon 執行中有人 `rm -rf ~/.agend/instances/<name>`，健康檢查每 ~30s 會不斷嘗試 respawn，產生 `ENOENT … rotation-state.json` / `tmux server died` / `Failed to respawn Claude window` 的連鎖錯誤 spam。現在每次 tick 開頭會檢查 `instanceDir` 是否還存在，不存在就暫停該 instance 的健康檢查。
+- **Instance 目錄被外部刪除時健康檢查迴圈會停止** (PR #46) — 先前若 daemon 執行中有人 `rm -rf ~/.agend/instances/<name>`，健康檢查每 ~30s 會不斷嘗試 respawn，產生 `ENOENT … rotation-state.json` / `tmux server died` / `Failed to respawn Claude window` 的連鎖錯誤 spam。現在每次 tick 開頭會檢查 `instanceDir` 是否還存在，不存在就暫停該 instance 的健康檢查。
 
 ## [1.23.0] - 2026-04-20
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@suzuke/agend",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@suzuke/agend",
-      "version": "1.23.0",
+      "version": "1.23.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suzuke/agend",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "Multi-agent fleet daemon — run any coding CLI (Claude, Gemini, Codex, OpenCode) from Telegram",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Patch release containing the daemon health-check fix from PR #46.

## Summary
- Bump version 1.23.0 → 1.23.1
- Move CHANGELOG [Unreleased] → [1.23.1] in both en and zh-TW

## Test plan
- [x] PR #46 merged, full suite 508/508 green pre-merge