### PR TITLE
chore(discord-plugin): sync package-lock.json to 1.1.0

### DIFF
--- a/plugins/agend-plugin-discord/package-lock.json
+++ b/plugins/agend-plugin-discord/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "agend-plugin-discord",
-  "version": "1.0.0",
+  "name": "@suzuke/agend-plugin-discord",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agend-plugin-discord",
-      "version": "1.0.0",
+      "name": "@suzuke/agend-plugin-discord",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "discord.js": "^14.25.1"


### PR DESCRIPTION
Follow-up to #49. Lock file was stale (still pinned at 1.0.0) and also carried the unscoped name `agend-plugin-discord` from before the scoped-name rename (`c84f14a`). Regenerated via `npm install` in the plugin dir.