### PR TITLE
chore: release 1.24.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.24.0] - 2026-04-21
+
+### Added
+- **Discord quickstart UX** (PR #48) — `agend quickstart` now checks for `@suzuke/agend-plugin-discord` before the Discord flow, auto-lists text channels from the Discord API to pick `options.general_channel_id`, and asks for `options.category_name`. Missing plugin shows install hint with opt-in continue.
+
 ## [1.23.1] - 2026-04-21
 
 ### Fixed

--- a/docs/CHANGELOG.zh-TW.md
+++ b/docs/CHANGELOG.zh-TW.md
@@ -6,6 +6,11 @@
 
 ## [未發佈] (Unreleased)
 
+## [1.24.0] - 2026-04-21
+
+### 新增 (Added)
+- **Discord quickstart 體驗改進** (PR #48) — `agend quickstart` 在走 Discord 流程前會先檢查是否安裝 `@suzuke/agend-plugin-discord`，並自動呼叫 Discord API 列出文字頻道供使用者挑選 `options.general_channel_id`，同時詢問 `options.category_name`。若 plugin 未安裝會顯示安裝提示並允許選擇繼續。
+
 ## [1.23.1] - 2026-04-21
 
 ### 修復 (Fixed)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@suzuke/agend",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@suzuke/agend",
-      "version": "1.23.1",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suzuke/agend",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "description": "Multi-agent fleet daemon — run any coding CLI (Claude, Gemini, Codex, OpenCode) from Telegram",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump `@suzuke/agend` from 1.23.1 → 1.24.0 (minor, feature)
- Roll up PR #48 (Discord quickstart UX improvements)

## Test plan
- [x] `package.json` / `package-lock.json` synced
- [x] `docs/CHANGELOG.md` + `docs/CHANGELOG.zh-TW.md` entry added
- [ ] After merge: `npm run build && npm publish` from main