### PR TITLE
fix(broadcast): close cost-guard gate gap (#24 follow-up — broadcast surface)

### DIFF
--- a/src/outbound-handlers.ts
+++ b/src/outbound-handlers.ts
@@ -396,7 +396,20 @@ const broadcast: Handler = (ctx, rawArgs, respond, meta) => {
 
   const sentTo: string[] = [];
   const failed: string[] = [];
+  // #24 follow-up: per-target cost-guard skip. Unlike sendToInstance (which
+  // short-circuits the whole call), broadcast must keep dispatching to other
+  // targets — only the over-limit ones drop out. BroadcastRequestKind already
+  // excludes "report", so no kind-bypass needed here.
+  const costLimited: { target: string; warning: string }[] = [];
   for (const targetName of targetNames) {
+    if (ctx.costGuard?.isLimited(targetName)) {
+      const limitUsd = (ctx.costGuard.getLimitCents() / 100).toFixed(2);
+      costLimited.push({
+        target: targetName,
+        warning: `cost-guard: instance '${targetName}' has reached its daily cost limit ($${limitUsd}). Message not delivered — target is paused.`,
+      });
+      continue;
+    }
     const targetIpc = ctx.instanceIpcClients.get(targetName) ?? ctx.instanceIpcClients.get(ctx.sessionRegistry.get(targetName) ?? "");
     if (!targetIpc) { failed.push(targetName); continue; }
 
@@ -420,7 +433,7 @@ const broadcast: Handler = (ctx, rawArgs, respond, meta) => {
     ctx.eventLog?.logActivity("message", senderLabel, summary, target);
   }
   ctx.queueMirrorMessage?.(`📢 ${senderLabel} → [${sentTo.join(", ")}]: ${message.slice(0, 500)}${message.length > 500 ? " […]" : ""}`);
-  respond({ sent_to: sentTo, failed, count: sentTo.length });
+  respond({ sent_to: sentTo, failed, cost_limited: costLimited, count: sentTo.length });
 };
 
 // ── Teams ────────────────────────────────────────────────────────────────

--- a/tests/outbound-cost-guard-precheck.test.ts
+++ b/tests/outbound-cost-guard-precheck.test.ts
@@ -182,3 +182,136 @@ describe("Feature #24 — cost-guard pre-check at outbound dispatch", () => {
     });
   });
 });
+
+// ── #24 follow-up: broadcast handler gap ────────────────────────────────────
+//
+// `broadcast` runs its own per-target send loop without funnelling through
+// sendToInstance, so PR #57's gate did not cover it. ts-reviewer flagged the
+// gap on PR #57 (Out-of-scope Observation 1). This block verifies the gate
+// in three states, scoped per ts-lead's follow-up dispatch:
+//   (a) mixed — limited targets warn + skip, others receive
+//   (b) all limited — every target warns, zero IPC sends
+//   (c) all not limited — behaves identically to pre-fix
+//
+// BroadcastRequestKind already excludes "report", so no kind-bypass is needed.
+
+interface MockTargetSet {
+  ipcs: Record<string, MockIpcChannel>;
+  ctx: any; // OutboundContext; uses vitest mocks so cast for brevity
+}
+
+function makeBroadcastCtx(targetNames: string[], costGuard: CostGuardMock | null): MockTargetSet {
+  const ipcs: Record<string, MockIpcChannel> = {};
+  const instanceIpcClients = new Map<string, { send: (msg: unknown) => void }>();
+  // sender's own ipc — broadcast filters it out by name match
+  const senderIpc = mockIpc();
+  ipcs.sender = senderIpc;
+  instanceIpcClients.set("sender", senderIpc.ipc);
+  for (const name of targetNames) {
+    const ch = mockIpc();
+    ipcs[name] = ch;
+    instanceIpcClients.set(name, ch.ipc);
+  }
+  return {
+    ipcs,
+    ctx: {
+      fleetConfig: { instances: Object.fromEntries(["sender", ...targetNames].map(n => [n, { working_directory: `/tmp/${n}` }])) },
+      adapter: null,
+      logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+      routing: { resolve: () => undefined },
+      instanceIpcClients,
+      lifecycle: { daemons: new Map() },
+      sessionRegistry: new Map(),
+      eventLog: null,
+      costGuard,
+      lastActivityMs: () => 0,
+      startInstance: vi.fn(),
+      connectIpcToInstance: vi.fn(),
+      saveFleetConfig: vi.fn(),
+    },
+  };
+}
+
+describe("#24 follow-up — cost-guard pre-check at broadcast dispatch", () => {
+  // Per-target isLimited mock: only the names in `limitedSet` are over budget.
+  function partialCostGuard(limitedSet: Set<string>, limitUsd = 5): CostGuardMock {
+    const limitCents = limitUsd * 100;
+    return {
+      isLimited: vi.fn((name: string) => limitedSet.has(name)),
+      getLimitCents: vi.fn(() => limitCents),
+      getDailyCostCents: vi.fn((name: string) => limitedSet.has(name) ? limitCents + 100 : 0),
+    };
+  }
+
+  it("(a) mixed targets — limited skipped with warning, others delivered", async () => {
+    const cg = partialCostGuard(new Set(["target-b"]));
+    const { ctx, ipcs } = makeBroadcastCtx(["target-a", "target-b", "target-c"], cg);
+    const handler = outboundHandlers.get("broadcast")!;
+    const respond = vi.fn();
+
+    await handler(ctx, { message: "hello fleet", targets: ["target-a", "target-b", "target-c"] }, respond, meta);
+
+    expect(ipcs["target-a"].messages).toHaveLength(1);
+    expect(ipcs["target-b"].messages).toHaveLength(0);
+    expect(ipcs["target-c"].messages).toHaveLength(1);
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    const result = respond.mock.calls[0][0] as {
+      sent_to: string[];
+      failed: string[];
+      cost_limited: { target: string; warning: string }[];
+      count: number;
+    };
+    expect(result.sent_to).toEqual(["target-a", "target-c"]);
+    expect(result.cost_limited).toHaveLength(1);
+    expect(result.cost_limited[0].target).toBe("target-b");
+    expect(result.cost_limited[0].warning).toContain("cost-guard");
+    expect(result.cost_limited[0].warning).toContain("'target-b'");
+    expect(result.cost_limited[0].warning).toContain("$5.00");
+    expect(result.failed).toEqual([]);
+    expect(result.count).toBe(2);
+  });
+
+  it("(b) all targets limited — every target warns, zero IPC sends", async () => {
+    const cg = partialCostGuard(new Set(["target-a", "target-b", "target-c"]));
+    const { ctx, ipcs } = makeBroadcastCtx(["target-a", "target-b", "target-c"], cg);
+    const handler = outboundHandlers.get("broadcast")!;
+    const respond = vi.fn();
+
+    await handler(ctx, { message: "hello fleet", targets: ["target-a", "target-b", "target-c"] }, respond, meta);
+
+    expect(ipcs["target-a"].messages).toHaveLength(0);
+    expect(ipcs["target-b"].messages).toHaveLength(0);
+    expect(ipcs["target-c"].messages).toHaveLength(0);
+
+    const result = respond.mock.calls[0][0] as {
+      sent_to: string[];
+      cost_limited: { target: string }[];
+      count: number;
+    };
+    expect(result.sent_to).toEqual([]);
+    expect(result.cost_limited.map(e => e.target).sort()).toEqual(["target-a", "target-b", "target-c"]);
+    expect(result.count).toBe(0);
+  });
+
+  it("(c) no targets limited — behaves identically to pre-fix (cost_limited empty)", async () => {
+    const cg = partialCostGuard(new Set());
+    const { ctx, ipcs } = makeBroadcastCtx(["target-a", "target-b"], cg);
+    const handler = outboundHandlers.get("broadcast")!;
+    const respond = vi.fn();
+
+    await handler(ctx, { message: "hello fleet", targets: ["target-a", "target-b"] }, respond, meta);
+
+    expect(ipcs["target-a"].messages).toHaveLength(1);
+    expect(ipcs["target-b"].messages).toHaveLength(1);
+
+    const result = respond.mock.calls[0][0] as {
+      sent_to: string[];
+      cost_limited: unknown[];
+      count: number;
+    };
+    expect(result.sent_to).toEqual(["target-a", "target-b"]);
+    expect(result.cost_limited).toEqual([]);
+    expect(result.count).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

PR #57 (the #24 fix) gated `sendToInstance` and — transitively via `wrapAsSend` — `delegate_task` and `request_information`. But `broadcast` runs its own per-target send loop without funnelling through `sendToInstance`, so a limited instance could still be flooded with broadcast `task` / `query` / `update` messages. ts-reviewer flagged this on PR #57 as Out-of-scope Observation 1. This PR closes the gap so the #24 issue intent ("notify sender on cost-guard limit") covers all outbound-dispatch surfaces an agent can use.

## Changes

- `src/outbound-handlers.ts.broadcast` (~10 LOC): inside the per-target loop, when `ctx.costGuard?.isLimited(target)` is true, append the target to a new `costLimited` array with the same warning string format used in #57 (`cost-guard: instance '...' has reached its daily cost limit ($X.XX). ...`) and `continue` instead of dispatching. Other targets keep flowing normally — broadcast is never short-circuited as a whole.
- broadcast result gains `cost_limited: [{ target, warning }]` alongside `sent_to`, `failed`, `count`. Callers can see exactly which targets were skipped and why.

## Out of scope (per ts-lead)

- Session-routing edge case (Out-of-scope Observation 2 from PR #57): gate keys by `targetName` directly, not by the resolved host. Deferred per dispatch.
- `request_kind: "report"` bypass: not applicable here. `BroadcastRequestKind` (outbound-schemas.ts) already restricts to `"query" | "task" | "update"` — broadcasts never carry reports because they have no correlation_id to terminate.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 63 files / 527 tests pass (+3 over post-#57 baseline; no regressions)
- [x] `tests/outbound-cost-guard-precheck.test.ts` — three operator-mandated states for broadcast:
  - **(a) mixed** → limited targets warned + skipped (no IPC send), others delivered. Result `cost_limited` contains exactly the limited target with the standard warning string.
  - **(b) all limited** → zero IPC sends across all targets, `cost_limited` lists all, `sent_to` empty, `count: 0`.
  - **(c) no targets limited** → identical to pre-fix behaviour (`cost_limited: []`, `sent_to` matches all targets).

## Risks considered

- **Result shape change**: adds new `cost_limited` field. Existing callers reading `sent_to` / `failed` / `count` see no change. New field default is `[]`, never null. No migration needed.
- **Concurrent cost-guard state changes during loop**: same race surface as pre-existing pause flow — gate shrinks the window per target but doesn't eliminate it. Not introduced here.
- **Performance**: `isLimited()` is O(1) (Map lookup + arithmetic). Per-target overhead negligible.

## Files

- `src/outbound-handlers.ts` — broadcast loop gate + result field
- `tests/outbound-cost-guard-precheck.test.ts` — 3 broadcast tests appended

🤖 Generated with [Claude Code](https://claude.com/claude-code)