### PR TITLE
chore(github): add ISSUE_TEMPLATE config redirecting new features to agend-terminal

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "🚀 New features → agend-terminal (Rust successor)"
+    url: https://github.com/suzuke/agend-terminal/issues/new
+    about: "AgEnD (TS) is in maintenance mode. New features and most non-security issues land in agend-terminal. Blank issues remain open for security reports and critical bugs."


### PR DESCRIPTION
Sprint 1 Track 2 (deliverable 2 of 2 in this track).

Keep \`blank_issues_enabled: true\` so security reports and critical bugs can still be filed against this repo during maintenance mode. Add a contact link that redirects feature requests and most non-security issues to the agend-terminal (Rust successor) repo.

## Track 2 status (informational)

- [x] Created GitHub labels: \`migrated-to-agend-terminal\` (#50bf60), \`wontfix-deprecated\` (#888888), \`bug-fixed-in-maintenance\` (#fbca04)
- [x] Applied \`migrated-to-agend-terminal\` to closed issues #52 #53 #54 #8 (Sprint 0 close-with-migration set)
- [x] Applied \`bug-fixed-in-maintenance\` to closed issue #55 (Sprint 0 fix delivery — signals \"deprecated repo still ships critical bug fixes\")
- [x] This PR — ISSUE_TEMPLATE redirect

Track 1 (docs banner audit) running in parallel as PR #?? from ts-impl.

## Authority
Authored under operator overnight delegation \`d-20260427025246010573-0\`.