### PR TITLE
docs: add deprecation banner to user-facing docs (Sprint 1 Track 1)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+> [!WARNING]
+> **AgEnD is in maintenance mode.** Active development has moved to
+> **[agend-terminal](https://github.com/suzuke/agend-terminal)**. Future entries in
+> this changelog will cover security fixes and backend CLI compatibility updates
+> only — feature work lands in the new repository.
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).

--- a/docs/CHANGELOG.zh-TW.md
+++ b/docs/CHANGELOG.zh-TW.md
@@ -1,5 +1,10 @@
 # 更新日誌 (Changelog)
 
+> [!WARNING]
+> **AgEnD 已進入 maintenance mode**。新功能開發已移至
+> **[agend-terminal](https://github.com/suzuke/agend-terminal)**。本日誌之後的新增條目將
+> 僅涵蓋安全修補與後端 CLI 相容性更新 —— 新功能開發以新 repo 為主。
+
 本專案的所有顯著變更都將記錄在此檔案中。
 
 格式基於 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,14 @@
 # AgEnD Roadmap
 
+> [!WARNING]
+> **AgEnD is in maintenance mode.** Active development has moved to
+> **[agend-terminal](https://github.com/suzuke/agend-terminal)** — a Rust rewrite with
+> native PTY multiplexing, cross-platform support (macOS / Linux / Windows), and a
+> built-in multi-pane TUI. All new features land there.
+>
+> This roadmap captures the planning state of `@suzuke/agend` at v1.12.0 and is
+> retained for historical reference. Future direction is tracked in `agend-terminal`.
+
 > Last updated: 2026-04-06 (v1.12.0)
 > Produced by multi-agent consensus: Claude Code, Codex, Gemini CLI, OpenCode, Kiro CLI
 

--- a/docs/ROADMAP.zh-TW.md
+++ b/docs/ROADMAP.zh-TW.md
@@ -1,5 +1,14 @@
 # AgEnD 發展藍圖
 
+> [!WARNING]
+> **AgEnD 已進入 maintenance mode**。新功能開發已移至
+> **[agend-terminal](https://github.com/suzuke/agend-terminal)** —— 一個以 Rust 重寫的版本,
+> 具備原生 PTY multiplexing、跨平台支援 (macOS / Linux / Windows),以及內建的多 pane TUI。
+> 所有新功能都將在該版本推出。
+>
+> 本藍圖紀錄的是 `@suzuke/agend` 在 v1.12.0 時的規劃狀態,僅作歷史參考。後續方向以
+> `agend-terminal` 為準。
+
 > 最後更新：2026-04-06 (v1.12.0)
 > 由多代理共識產出：Claude Code, Codex, Gemini CLI, OpenCode, Kiro CLI
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,5 +1,13 @@
 # Security Considerations
 
+> [!WARNING]
+> **AgEnD is in maintenance mode.** Active development has moved to
+> **[agend-terminal](https://github.com/suzuke/agend-terminal)**.
+>
+> Security reports for `@suzuke/agend` are still accepted — please file via the
+> process described in this document. New code reports should target
+> `agend-terminal`.
+
 Running Claude Code remotely via Telegram changes the trust model compared to sitting at a terminal. Be aware of the following:
 
 ## Telegram account = shell access

--- a/docs/SECURITY.zh-TW.md
+++ b/docs/SECURITY.zh-TW.md
@@ -1,5 +1,12 @@
 # 安全考量 (Security Considerations)
 
+> [!WARNING]
+> **AgEnD 已進入 maintenance mode**。新功能開發已移至
+> **[agend-terminal](https://github.com/suzuke/agend-terminal)**。
+>
+> `@suzuke/agend` 的安全回報仍然受理 —— 請依本文件描述的流程提交。針對新版程式碼的
+> 安全回報請改提交至 `agend-terminal`。
+
 透過 Telegram 遠端執行 Claude Code 與坐在終端機前相比，會改變信任模型。請注意以下事項：
 
 ## Telegram 帳號 = Shell 存取權限

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,5 +1,13 @@
 # CLI Reference
 
+> [!WARNING]
+> **AgEnD is in maintenance mode.** Active development has moved to
+> **[agend-terminal](https://github.com/suzuke/agend-terminal)** — a Rust rewrite with
+> native PTY multiplexing, cross-platform support (macOS / Linux / Windows), and a
+> built-in multi-pane TUI. All new features land there.
+>
+> This document remains for users on existing `@suzuke/agend` installs.
+
 ## Telegram commands (General topic)
 
 | Command | Description |

--- a/docs/cli.zh-TW.md
+++ b/docs/cli.zh-TW.md
@@ -1,5 +1,13 @@
 # CLI 參考 (CLI Reference)
 
+> [!WARNING]
+> **AgEnD 已進入 maintenance mode**。新功能開發已移至
+> **[agend-terminal](https://github.com/suzuke/agend-terminal)** —— 一個以 Rust 重寫的版本,
+> 具備原生 PTY multiplexing、跨平台支援 (macOS / Linux / Windows),以及內建的多 pane TUI。
+> 所有新功能都將在該版本推出。
+>
+> 本文件僅為現有 `@suzuke/agend` 安裝的使用者保留。
+
 ## Telegram 指令 (General 主題)
 
 | 指令 | 描述 |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,13 @@
 # Configuration
 
+> [!WARNING]
+> **AgEnD is in maintenance mode.** Active development has moved to
+> **[agend-terminal](https://github.com/suzuke/agend-terminal)** — a Rust rewrite with
+> native PTY multiplexing, cross-platform support (macOS / Linux / Windows), and a
+> built-in multi-pane TUI. All new features land there.
+>
+> This document remains for users on existing `@suzuke/agend` installs.
+
 ## Fleet config
 
 Located at `~/.agend/fleet.yaml`. Created by `agend init` or manually.

--- a/docs/configuration.zh-TW.md
+++ b/docs/configuration.zh-TW.md
@@ -1,5 +1,13 @@
 # 設定參考
 
+> [!WARNING]
+> **AgEnD 已進入 maintenance mode**。新功能開發已移至
+> **[agend-terminal](https://github.com/suzuke/agend-terminal)** —— 一個以 Rust 重寫的版本,
+> 具備原生 PTY multiplexing、跨平台支援 (macOS / Linux / Windows),以及內建的多 pane TUI。
+> 所有新功能都將在該版本推出。
+>
+> 本文件僅為現有 `@suzuke/agend` 安裝的使用者保留。
+
 ## Fleet 設定檔
 
 位置：`~/.agend/fleet.yaml`。由 `agend init` 建立或手動編輯。

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,5 +1,14 @@
 # Features
 
+> [!WARNING]
+> **AgEnD is in maintenance mode.** Active development has moved to
+> **[agend-terminal](https://github.com/suzuke/agend-terminal)** — a Rust rewrite with
+> native PTY multiplexing, cross-platform support (macOS / Linux / Windows), and a
+> built-in multi-pane TUI. All new features land there.
+>
+> This document describes the feature surface of `@suzuke/agend`. New features in
+> `agend-terminal` may differ.
+
 ## Fleet mode — one bot, many projects
 
 Each Telegram Forum Topic maps to an independent Claude Code session. Create a topic, pick a project directory, and Claude starts working. Delete the topic, instance stops. Scale to as many projects as your machine can handle.

--- a/docs/features.zh-TW.md
+++ b/docs/features.zh-TW.md
@@ -1,5 +1,13 @@
 # 功能 (Features)
 
+> [!WARNING]
+> **AgEnD 已進入 maintenance mode**。新功能開發已移至
+> **[agend-terminal](https://github.com/suzuke/agend-terminal)** —— 一個以 Rust 重寫的版本,
+> 具備原生 PTY multiplexing、跨平台支援 (macOS / Linux / Windows),以及內建的多 pane TUI。
+> 所有新功能都將在該版本推出。
+>
+> 本文件描述 `@suzuke/agend` 的功能範圍,`agend-terminal` 的新功能可能有所差異。
+
 ## Fleet 模式 — 一個機器人，多個專案
 
 每個 Telegram 論壇主題 (Forum Topic) 都映射到一個獨立的 Claude Code session。建立主題、選擇專案目錄，Claude 就會開始工作。刪除主題，實例 (instance) 就會停止。擴展到您的機器所能處理的任意數量的專案。

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -1,5 +1,14 @@
 # Plugin Development Guide
 
+> [!WARNING]
+> **AgEnD is in maintenance mode.** Active development has moved to
+> **[agend-terminal](https://github.com/suzuke/agend-terminal)** — a Rust rewrite with
+> native PTY multiplexing, cross-platform support (macOS / Linux / Windows), and a
+> built-in multi-pane TUI. All new features land there.
+>
+> This guide remains for plugin authors targeting existing `@suzuke/agend` installs.
+> The plugin protocol in `agend-terminal` may differ.
+
 Build channel adapter plugins for AgEnD. This guide uses the Discord adapter (`@suzuke/agend-plugin-discord`) as a reference implementation.
 
 ## Plugin Architecture


### PR DESCRIPTION
## Summary

Aligns user-facing docs with README's deprecation notice. Internal design docs unchanged per Sprint 1 scope. See `docs/ts-team-sprint-0-2026-04-27-wrap.md` for context.

Banner placement: directly after each H1, before existing content (in some cases before existing metadata blocks like ROADMAP's "Last updated" line — banner stays at top).

## Per-doc choices

| Doc | Banner type | Rationale |
|---|---|---|
| `cli.md` / `cli.zh-TW.md` | standard | reference doc; users on existing installs need it |
| `configuration.md` / `configuration.zh-TW.md` | standard | same |
| `features.md` / `features.zh-TW.md` | standard + feature-surface caveat | future agend-terminal features may differ |
| `plugin-development.md` | standard + plugin-protocol caveat | plugin protocol may differ in new repo |
| `ROADMAP.md` / `ROADMAP.zh-TW.md` | standard + historical-snapshot note | roadmap captures v1.12.0 state, future direction is in agend-terminal |
| `SECURITY.md` / `SECURITY.zh-TW.md` | standard + reports-still-accepted | README explicitly continues security fixes; this doc remains the report channel |
| `CHANGELOG.md` / `CHANGELOG.zh-TW.md` | standard + future-entries-scope | future entries cover security fixes and backend CLI compat only |

zh-TW versions translate banner body to 繁體中文 while retaining English for GitHub URLs (`agend-terminal`) and brand keywords.

## Hard rule (general's explicit instruction)

**No internal design docs touched.** Verified via `git diff --name-only origin/main`:

```
docs/CHANGELOG.md
docs/CHANGELOG.zh-TW.md
docs/ROADMAP.md
docs/ROADMAP.zh-TW.md
docs/SECURITY.md
docs/SECURITY.zh-TW.md
docs/cli.md
docs/cli.zh-TW.md
docs/configuration.md
docs/configuration.zh-TW.md
docs/features.md
docs/features.zh-TW.md
docs/plugin-development.md
```

None of these are touched: `superpowers/`, `specs/`, `fix-plan.md`, `p4.1-split-plan.md`, `design-ux-pain-points.md`, `rebrand-plan.md`, `multi-backend-feasibility.md`, `plugin-adapter-architecture.md`, `approval-system-analysis.md`, `context-rotation-design.md`, `cross-cli-research.md`, `cross-instance-messaging.md`, `feature-roadmap.md`, `issue-evaluations.md`, `token-overhead-report*.md`. Reviewer can re-confirm with the same command.

## Stats

- 13 files changed, 102 insertions(+). Pure banner additions, no content rewrite.

## Test plan

- [x] `git diff --name-only origin/main` confirms only user-facing docs touched
- [x] Banner placement: directly after H1 in every modified file (verified by reading the resulting first ~10 lines of each)
- [x] zh-TW translations preserve GitHub URLs / `agend-terminal` keyword in English
- N/A vitest / tsc — pure docs change

🤖 Generated with [Claude Code](https://claude.com/claude-code)